### PR TITLE
Add tpm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,18 @@ license = "MPL-2.0"
 
 [features]
 unsafe_release_without_verify = []
+hsm-crypto = ["kanidm-hsm-crypto"]
 default = ["openssl"]
+
+[patch.crates-io]
+# kanidm-hsm-crypto = { path = "../hsm-crypto" }
 
 [dependencies]
 serde = { version = "^1.0.136", features = ["derive"] }
 serde_json = "^1.0.79"
 base64 = "^0.21.5"
 base64urlsafedata = "0.1.0"
+kanidm-hsm-crypto = { version = "^0.1.2", optional = true }
 openssl = { version = "^0.10.38", optional = true }
 url = { version = "^2.2.2", features = ["serde"] }
 uuid = { version = "^1.0.0", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact_jwt"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["William Brown <william@blackhats.net.au>"]
 description = "Minimal implementation of JWT for OIDC and other applications"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -11,10 +11,16 @@ mod hs256;
 mod rs256;
 mod x509;
 
+#[cfg(feature = "hsm-crypto")]
+mod tpm;
+
 pub use es256::{JwsEs256Signer, JwsEs256Verifier};
 pub use hs256::JwsHs256Signer;
 pub use rs256::{JwsRs256Signer, JwsRs256Verifier};
 pub use x509::{JwsX509Verifier, JwsX509VerifierBuilder};
+
+#[cfg(feature = "hsm-crypto")]
+pub use tpm::JwsTpmSigner;
 
 impl JwsCompact {
     #[cfg(test)]

--- a/src/crypto/tpm.rs
+++ b/src/crypto/tpm.rs
@@ -1,0 +1,178 @@
+use crate::compact::{JwaAlg, JwsCompact, ProtectedHeader};
+use crate::error::JwtError;
+use crate::traits::*;
+use base64::{engine::general_purpose, Engine as _};
+use kanidm_hsm_crypto::{IdentityKey, KeyAlgorithm, Tpm};
+
+pub struct JwsTpmSigner<'a, T: Tpm> {
+    kid: String,
+    tpm: &'a mut T,
+    id_key: &'a IdentityKey,
+}
+
+impl<'a, T> JwsTpmSigner<'a, T>
+where
+    T: Tpm,
+{
+    pub fn new(tpm: &'a mut T, id_key: &'a IdentityKey) -> Result<Self, JwtError> {
+        let kid = tpm
+            .identity_key_id(id_key)
+            .map(hex::encode)
+            .map_err(|_err| JwtError::TpmError)?;
+
+        Ok(JwsTpmSigner { kid, tpm, id_key })
+    }
+}
+
+impl<'a, T> JwsMutSigner for JwsTpmSigner<'a, T>
+where
+    T: Tpm,
+{
+    fn get_kid(&mut self) -> &str {
+        self.kid.as_str()
+    }
+
+    fn update_header(&mut self, header: &mut ProtectedHeader) -> Result<(), JwtError> {
+        // Update the alg to match.
+        header.alg = JwaAlg::ES256;
+
+        header.kid = Some(self.kid.clone());
+
+        // if were were asked to ember the jwk, do so now.
+        /*
+        if self.sign_option_embed_jwk {
+            header.jwk = self.public_key_as_jwk().map(Some)?;
+        }
+        */
+
+        Ok(())
+    }
+
+    fn sign<V: JwsSignable>(&mut self, jws: &V) -> Result<V::Signed, JwtError> {
+        let mut sign_data = jws.data()?;
+
+        // Let the signer update the header as required.
+        self.update_header(&mut sign_data.header)?;
+
+        let hdr_b64 = serde_json::to_vec(&sign_data.header)
+            .map_err(|e| {
+                debug!(?e);
+                JwtError::InvalidHeaderFormat
+            })
+            .map(|bytes| general_purpose::URL_SAFE_NO_PAD.encode(bytes))?;
+
+        let mut hash_data = Vec::with_capacity(hdr_b64.len() + 1 + sign_data.payload_b64.len());
+        hash_data.extend_from_slice(hdr_b64.as_bytes());
+        hash_data.extend_from_slice(".".as_bytes());
+        hash_data.extend_from_slice(sign_data.payload_b64.as_bytes());
+
+        let signature = self
+            .tpm
+            .identity_key_sign(self.id_key, &hash_data)
+            .map_err(|_err| JwtError::TpmError)?;
+
+        let jwsc = JwsCompact {
+            header: sign_data.header,
+            hdr_b64,
+            payload_b64: sign_data.payload_b64,
+            signature,
+        };
+
+        jws.post_process(jwsc)
+    }
+}
+
+impl<'a, T> JwsMutVerifier for JwsTpmSigner<'a, T>
+where
+    T: Tpm,
+{
+    /// Get the key id from this verifier
+    fn get_kid(&mut self) -> Option<&str> {
+        Some(JwsMutSigner::get_kid(self))
+    }
+
+    /// Perform the signature verification
+    fn verify<V: JwsVerifiable>(&mut self, jwsc: &V) -> Result<V::Verified, JwtError> {
+        let signed_data = jwsc.data();
+
+        match (signed_data.header.alg, self.id_key.alg()) {
+            (JwaAlg::ES256, KeyAlgorithm::Ecdsa256) | (JwaAlg::RS256, KeyAlgorithm::Rsa2048) => {}
+            (jwsc_alg, key_alg) => {
+                debug!(?jwsc_alg, ?key_alg, "validator algorithm mismatch");
+                return Err(JwtError::ValidatorAlgMismatch);
+            }
+        };
+
+        let mut hash_data =
+            Vec::with_capacity(signed_data.hdr_bytes.len() + 1 + signed_data.payload_bytes.len());
+        hash_data.extend_from_slice(signed_data.hdr_bytes);
+        hash_data.extend_from_slice(".".as_bytes());
+        hash_data.extend_from_slice(signed_data.payload_bytes);
+
+        let valid = self
+            .tpm
+            .identity_key_verify(self.id_key, &hash_data, signed_data.signature_bytes)
+            .map_err(|e| {
+                debug!(?e);
+                JwtError::TpmError
+            })?;
+
+        if valid {
+            signed_data.release().and_then(|d| jwsc.post_process(d))
+        } else {
+            debug!("invalid signature");
+            Err(JwtError::InvalidSignature)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JwsTpmSigner;
+    use kanidm_hsm_crypto::{soft::SoftTpm, AuthValue, KeyAlgorithm, Tpm};
+    // use crate::compact::{Jwk, JwsCompact};
+    use crate::jws::JwsBuilder;
+    use crate::traits::*;
+
+    #[test]
+    fn tpm_key_generate_cycle() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        // Setup the tpm
+        let mut softtpm = SoftTpm::new();
+        let auth_value = AuthValue::new_random().unwrap();
+
+        let loadable_machine_key = softtpm.machine_key_create(&auth_value).unwrap();
+
+        let machine_key = softtpm
+            .machine_key_load(&auth_value, &loadable_machine_key)
+            .unwrap();
+
+        let loadable_id_key = softtpm
+            .identity_key_create(&machine_key, KeyAlgorithm::Ecdsa256)
+            .unwrap();
+
+        let id_key = softtpm
+            .identity_key_load(&machine_key, &loadable_id_key)
+            .unwrap();
+
+        let mut jws_tpm_signer =
+            JwsTpmSigner::new(&mut softtpm, &id_key).expect("failed to construct signer.");
+
+        // This time we'll add the jwk pubkey and show it being used with the validator.
+        let jws = JwsBuilder::from(vec![0, 1, 2, 3, 4])
+            .set_kid(Some("abcd"))
+            .set_typ(Some("abcd"))
+            .set_cty(Some("abcd"))
+            .build();
+
+        // jws_tpm_signer.set_sign_option_embed_jwk(true);
+
+        let jwsc = jws_tpm_signer.sign(&jws).expect("Failed to sign");
+
+        let released = jws_tpm_signer
+            .verify(&jwsc)
+            .expect("Unable to validate jws");
+        assert!(released.payload() == &[0, 1, 2, 3, 4]);
+    }
+}

--- a/src/crypto/tpm.rs
+++ b/src/crypto/tpm.rs
@@ -4,6 +4,12 @@ use crate::traits::*;
 use base64::{engine::general_purpose, Engine as _};
 use kanidm_hsm_crypto::{IdentityKey, KeyAlgorithm, Tpm};
 
+/// A JWS signer that uses a TPM protected key for signing operations.
+///
+/// Due to the construction of TPM's, this struct is intended to be "short lived"
+/// relying on references to the TPM rather than taking ownership of it. This means
+/// unlike other Signer types, you will need to build this struct each time you want
+/// to perform a signing operation in most cases.
 pub struct JwsTpmSigner<'a, T: Tpm> {
     kid: String,
     tpm: &'a mut T,
@@ -14,6 +20,8 @@ impl<'a, T> JwsTpmSigner<'a, T>
 where
     T: Tpm,
 {
+    /// Create a new JwsTpmSigner that will use the provided Identity Key for signing
+    /// operations.
     pub fn new(tpm: &'a mut T, id_key: &'a IdentityKey) -> Result<Self, JwtError> {
         let kid = tpm
             .identity_key_id(id_key)

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum JwtError {
     CriticalExtension,
     /// OpenSSL failure
     OpenSSLError,
+    /// Tpm Failure
+    TpmError,
     /// Incorrect Algorithm for verification
     ValidatorAlgMismatch,
     /// Invalid JWT Key ID

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
-#![warn(missing_docs)]
+// #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 // Enable some groups of clippy lints.
 #![deny(clippy::suspicious)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 #![forbid(unsafe_code)]
 // Enable some groups of clippy lints.
 #![deny(clippy::suspicious)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -18,6 +18,20 @@ pub trait JwsSigner {
     fn sign<V: JwsSignable>(&self, _jws: &V) -> Result<V::Signed, JwtError>;
 }
 
+/// A trait defining how a JwsSigner will operate.
+///
+/// Note that due to the design of this api, you can NOT define your own signer.
+pub trait JwsMutSigner {
+    /// Get the key id from this signer
+    fn get_kid(&mut self) -> &str;
+
+    /// Update thee content of the header with signer specific data
+    fn update_header(&mut self, header: &mut ProtectedHeader) -> Result<(), JwtError>;
+
+    /// Perform the signature operation
+    fn sign<V: JwsSignable>(&mut self, _jws: &V) -> Result<V::Signed, JwtError>;
+}
+
 /// A trait allowing a signer to create it's corresponding verifier.
 ///
 /// Note that due to the design of this api, you can NOT define your own signer or verifier.
@@ -38,6 +52,17 @@ pub trait JwsVerifier {
 
     /// Perform the signature verification
     fn verify<V: JwsVerifiable>(&self, _jwsc: &V) -> Result<V::Verified, JwtError>;
+}
+
+/// A trait defining how a JwsVerifier will operate.
+///
+/// Note that due to the design of this api, you can NOT define your own verifier.
+pub trait JwsMutVerifier {
+    /// Get the key id from this verifier
+    fn get_kid(&mut self) -> Option<&str>;
+
+    /// Perform the signature verification
+    fn verify<V: JwsVerifiable>(&mut self, _jwsc: &V) -> Result<V::Verified, JwtError>;
 }
 
 /// A trait defining types that can be verified by a [JwsVerifier]


### PR DESCRIPTION
Adds tpm support as a backend for compact jwt

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
