### PR TITLE
Match the signing alg with id_key alg

### DIFF
--- a/src/crypto/tpm.rs
+++ b/src/crypto/tpm.rs
@@ -42,7 +42,10 @@ where
 
     fn update_header(&mut self, header: &mut ProtectedHeader) -> Result<(), JwtError> {
         // Update the alg to match.
-        header.alg = JwaAlg::ES256;
+        match self.id_key.alg() {
+            KeyAlgorithm::Ecdsa256 => header.alg = JwaAlg::ES256,
+            KeyAlgorithm::Rsa2048 => header.alg = JwaAlg::RS256,
+        }
 
         header.kid = Some(self.kid.clone());
 


### PR DESCRIPTION
Implements # .

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
