### PR TITLE
Provide the ability to specify the header x5c

### DIFF
--- a/src/jws.rs
+++ b/src/jws.rs
@@ -52,6 +52,16 @@ impl JwsBuilder {
         self
     }
 
+    /// Set the chain of certificates
+    pub fn set_x5c(mut self, x5c: Option<Vec<Vec<u8>>>) -> Self {
+        self.header.x5c = x5c.map(|v| {
+            v.into_iter()
+                .map(|c| general_purpose::STANDARD.encode(c))
+                .collect()
+        });
+        self
+    }
+
     /// Finalise this builder
     pub fn build(self) -> Jws {
         let JwsBuilder { header, payload } = self;


### PR DESCRIPTION
Himmelblau requires this for requesting a PRT.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
