### PR TITLE
20240104 compact jwe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-Compact JWT
-===========
+Compact JWT / JWE
+=================
 
 Json Web Tokens (JWT) are a popular method for creating signed transparent tokens that can be verified
 by clients and servers. They are enshrined in standards like OpenID Connect which causes them to
 be a widespread and required component of many modern web authentication system.
 
-JWT and Json Web Signature (JWS) however have a long track record of handling issues, which have
-led to security issues. This library will not be a complete implementation of JWT/JWS, instead
+Json Web Encryption (JWE) is an occasionally used method for sending secrets to a recipient
+or to create opaque tokens for services.
+
+JWE, JWT, and Json Web Signature (JWS) however have a long track record of handling issues, which have
+led to security issues. This library will not be a complete implementation of JWE/JWT/JWS, instead
 focusing on a minimal subset that can be secured and audited for correctness more closely within
 a limited set of use cases.
 
@@ -17,9 +20,13 @@ If you are:
 
 * creating ECDSA signed JWT tokens, or verify ECDSA signed JWT tokens
 * implementing OIDC as a relying party or authorisation server
-* wanting to use HMAC signatures
-* needing a minimal secure JWS implementation, this library is for you
+* wanting to use HMAC signatures for transparent json data
+* needing a minimal secure JWS implementation
 * using TPM bound keys for signing JWTs
+* creating opaque encrypted tokens protected with AES-128-GCM
+* receiving or sending encrypted data to an ECDSA key
+
+Then this library is for you
 
 If you need non-compact JWS, or other complex use cases, this library is not for you.
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -299,6 +299,9 @@ pub enum JweAlg {
     A128KW,
     /// AES 256 Key Wrap
     A256KW,
+    /// ECDH-ES
+    #[serde(rename = "ECDH-ES+A128KW")]
+    ECDH_ES_A128KW,
     /// RSA-OAEP
     #[serde(rename = "RSA-OAEP")]
     RSA_OAEP,
@@ -327,6 +330,10 @@ pub struct JweProtectedHeader {
     pub(crate) alg: JweAlg,
 
     pub(crate) enc: JweEnc,
+
+    // https://www.rfc-editor.org/rfc/rfc7518#section-4.6.1.1
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) epk: Option<Jwk>,
 
     // zip
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -297,15 +297,24 @@ pub enum JweAlg {
     /// AES 128 Key Wrap
     #[default]
     A128KW,
-    // https://www.rfc-editor.org/rfc/rfc7518#section-4.1
+    /// AES 256 Key Wrap
+    A256KW,
+    /// RSA-OAEP
+    #[serde(rename = "RSA-OAEP")]
+    RSA_OAEP,
 }
 
 #[derive(Debug, Serialize, Copy, Clone, Deserialize, PartialEq, Default)]
 #[allow(non_camel_case_types)]
 /// Encipherment algorithm
 pub enum JweEnc {
+    /// AES 128 GCM. Header is authenticated but not encrypted, the payload is
+    /// encrypted and authenticated.
     #[default]
     A128GCM,
+    /// AES 256 GCM. Header is authenticated but not encrypted, the payload is
+    /// encrypted and authenticated.
+    A256GCM,
     /// AES 128 CBC with HMAC 256
     /// WARNING: Decrypted values may not be correct as the CEK is not HMACed.
     #[serde(rename = "A128CBC-HS256")]
@@ -314,7 +323,7 @@ pub enum JweEnc {
 
 /// A header that will be signed and embedded in the Jws
 #[derive(Debug, Serialize, Clone, Deserialize, Default, PartialEq)]
-pub struct UnprotectedHeader {
+pub struct JweProtectedHeader {
     pub(crate) alg: JweAlg,
 
     pub(crate) enc: JweEnc,
@@ -351,7 +360,7 @@ pub struct UnprotectedHeader {
 
 #[derive(Clone)]
 pub struct JweCompact {
-    pub(crate) header: UnprotectedHeader,
+    pub(crate) header: JweProtectedHeader,
     pub(crate) hdr_b64: String,
     pub(crate) content_enc_key: Vec<u8>,
     pub(crate) iv: Vec<u8>,
@@ -391,7 +400,7 @@ impl FromStr for JweCompact {
             JwtError::InvalidCompactFormat
         })?;
 
-        let header: UnprotectedHeader = general_purpose::URL_SAFE_NO_PAD
+        let header: JweProtectedHeader = general_purpose::URL_SAFE_NO_PAD
             .decode(hdr_str)
             .map_err(|_| {
                 debug!("invalid base64 while decoding header");

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -365,6 +365,7 @@ pub struct JweProtectedHeader {
     // Don't allow extra header names?
 }
 
+/// A Compact JWE that is able to be deciphered or stringified for transmission
 #[derive(Clone)]
 pub struct JweCompact {
     pub(crate) header: JweProtectedHeader,

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -377,7 +377,7 @@ pub struct JweCompact {
 }
 
 impl JweCompact {
-    /// Get the KID used to encipher this Jws if present
+    /// Get the KID used to encipher this Jwe if present
     pub fn get_jwk_kid(&self) -> Option<&str> {
         self.header.kid.as_deref()
     }
@@ -400,7 +400,8 @@ impl FromStr for JweCompact {
     type Err = JwtError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // split on the ".".
+        // split on the ".". Remember this means to split on '.' 4 times to create
+        // 5 string segments.
         let mut siter = s.splitn(5, '.');
 
         let hdr_str = siter.next().ok_or_else(|| {

--- a/src/crypto/a128cbc_hs256.rs
+++ b/src/crypto/a128cbc_hs256.rs
@@ -1,7 +1,6 @@
 use crate::compact::JweCompact;
 use crate::JwtError;
 
-use openssl::aes::{unwrap_key, AesKey};
 use openssl::hash::MessageDigest;
 use openssl::pkey::PKey;
 use openssl::sign::Signer;

--- a/src/crypto/a128gcm.rs
+++ b/src/crypto/a128gcm.rs
@@ -52,7 +52,7 @@ impl JweEncipherInner for JweA128GCMEncipher {
         let mut header = jwe.header.clone();
         header.enc = JweEnc::A128GCM;
 
-        outer.set_header_alg(&mut header);
+        outer.set_header_alg(&mut header)?;
 
         // Clone the header and update it with our details.
         let hdr_b64 = serde_json::to_vec(&header)

--- a/src/crypto/a128gcm.rs
+++ b/src/crypto/a128gcm.rs
@@ -125,7 +125,6 @@ pub(crate) fn aes_gcm_encipher(
             error!(?ossl_err);
             JwtError::OpenSSLError
         })?;
-    // encrypter.pad(true);
 
     // Feed in additional data to be checked. Must be called before update.
     encrypter

--- a/src/crypto/a128gcm.rs
+++ b/src/crypto/a128gcm.rs
@@ -1,12 +1,8 @@
-use crate::compact::{JweCompact, JweEnc, JweProtectedHeader};
+use crate::compact::{JweCompact, JweEnc};
 use crate::jwe::Jwe;
 use crate::traits::*;
 use crate::JwtError;
 
-use openssl::aes::{unwrap_key, AesKey};
-use openssl::hash::MessageDigest;
-use openssl::pkey::PKey;
-use openssl::sign::Signer;
 use openssl::symm::{Cipher, Crypter, Mode};
 
 use base64::{engine::general_purpose, Engine as _};
@@ -50,6 +46,8 @@ impl JweEncipherInner for JweA128GCMEncipher {
     ) -> Result<JweCompact, JwtError> {
         let mut header = jwe.header.clone();
         header.enc = JweEnc::A128GCM;
+
+        outer.set_header_alg(&mut header);
 
         // Clone the header and update it with our details.
         let hdr_b64 = serde_json::to_vec(&header)
@@ -210,16 +208,8 @@ pub(crate) fn aes_gcm_decipher(
 #[cfg(test)]
 mod tests {
     use super::JweA128GCMEncipher;
-    use crate::compact::JweCompact;
     use crate::crypto::a128kw::JweA128KWEncipher;
-    use crate::traits::*;
-
-    use crate::compact::JweEnc;
     use crate::jwe::JweBuilder;
-
-    // use base64::{engine::general_purpose, Engine as _};
-    // use std::convert::TryFrom;
-    // use std::str::FromStr;
 
     #[test]
     fn a128kw_outer_a128gcm_inner() {

--- a/src/crypto/a128gcm.rs
+++ b/src/crypto/a128gcm.rs
@@ -1,0 +1,244 @@
+use crate::compact::{JweCompact, JweEnc, JweProtectedHeader};
+use crate::jwe::Jwe;
+use crate::traits::*;
+use crate::JwtError;
+
+use openssl::aes::{unwrap_key, AesKey};
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::sign::Signer;
+use openssl::symm::{Cipher, Crypter, Mode};
+
+use base64::{engine::general_purpose, Engine as _};
+use openssl::rand::rand_bytes;
+
+#[derive(Clone)]
+pub struct JweA128GCMEncipher {
+    aes_key: [u8; 16],
+}
+
+impl TryFrom<&[u8]> for JweA128GCMEncipher {
+    type Error = JwtError;
+
+    fn try_from(r_aes_key: &[u8]) -> Result<Self, Self::Error> {
+        if r_aes_key.len() != 16 {
+            return Err(JwtError::InvalidKey);
+        }
+
+        let mut aes_key = [0; 16];
+        aes_key.copy_from_slice(r_aes_key);
+
+        Ok(JweA128GCMEncipher { aes_key })
+    }
+}
+
+impl JweEncipherInner for JweA128GCMEncipher {
+    fn new_ephemeral() -> Result<Self, JwtError> {
+        let mut aes_key = [0; 16];
+        rand_bytes(&mut aes_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        Ok(JweA128GCMEncipher { aes_key })
+    }
+
+    fn encipher_inner<O: JweEncipherOuter>(
+        &self,
+        outer: &O,
+        jwe: &Jwe,
+    ) -> Result<JweCompact, JwtError> {
+        let mut header = jwe.header.clone();
+        header.enc = JweEnc::A128GCM;
+
+        // Clone the header and update it with our details.
+        let hdr_b64 = serde_json::to_vec(&header)
+            .map_err(|e| {
+                debug!(?e);
+                JwtError::InvalidHeaderFormat
+            })
+            .map(|bytes| general_purpose::URL_SAFE_NO_PAD.encode(bytes))?;
+
+        let content_enc_key = outer.wrap_key(&self.aes_key)?;
+
+        // 128 bit iv.
+        let mut iv = vec![0; 16];
+        rand_bytes(&mut iv).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        let authentication_tag_bytes = 16;
+
+        let (ciphertext, authentication_tag) = aes_gcm_encipher(
+            Cipher::aes_128_gcm(),
+            authentication_tag_bytes,
+            &jwe.payload,
+            hdr_b64.as_bytes(),
+            &self.aes_key,
+            &iv,
+        )?;
+
+        Ok(JweCompact {
+            header,
+            hdr_b64,
+            content_enc_key,
+            iv,
+            ciphertext,
+            authentication_tag,
+        })
+    }
+}
+
+impl JweA128GCMEncipher {
+    pub fn key_len() -> usize {
+        16
+    }
+
+    pub fn decipher_inner(&self, jwec: &JweCompact) -> Result<Vec<u8>, JwtError> {
+        aes_gcm_decipher(
+            Cipher::aes_128_gcm(),
+            &jwec.ciphertext,
+            jwec.hdr_b64.as_bytes(),
+            &self.aes_key,
+            &jwec.iv,
+            &jwec.authentication_tag,
+        )
+    }
+}
+
+pub(crate) fn aes_gcm_encipher(
+    cipher: Cipher,
+    authentication_tag_bytes: usize,
+    plaintext: &[u8],
+    authenticated_data: &[u8],
+    aes_key: &[u8],
+    iv: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), JwtError> {
+    let block_size = cipher.block_size();
+    let mut ciphertext = vec![0; plaintext.len() + block_size];
+
+    let mut encrypter =
+        Crypter::new(cipher, Mode::Encrypt, aes_key, Some(&iv)).map_err(|ossl_err| {
+            error!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+    // encrypter.pad(true);
+
+    // Feed in additional data to be checked. Must be called before update.
+    encrypter
+        .aad_update(authenticated_data)
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+    let mut count = encrypter
+        .update(plaintext, &mut ciphertext)
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+    count += encrypter.finalize(&mut ciphertext).map_err(|ossl_err| {
+        error!(?ossl_err);
+        JwtError::OpenSSLError
+    })?;
+
+    let mut authentication_tag = vec![0; authentication_tag_bytes];
+
+    encrypter
+        .get_tag(&mut authentication_tag)
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+    ciphertext.truncate(count);
+
+    Ok((ciphertext, authentication_tag))
+}
+
+pub(crate) fn aes_gcm_decipher(
+    cipher: Cipher,
+    ciphertext: &[u8],
+    authenticated_data: &[u8],
+    aes_key: &[u8],
+    iv: &[u8],
+    authentication_tag: &[u8],
+) -> Result<Vec<u8>, JwtError> {
+    let block_size = cipher.block_size();
+    let mut plaintext = vec![0; ciphertext.len() + block_size];
+
+    let mut decrypter =
+        Crypter::new(cipher, Mode::Decrypt, aes_key, Some(iv)).map_err(|ossl_err| {
+            error!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+    decrypter.pad(true);
+    decrypter.set_tag(authentication_tag).map_err(|ossl_err| {
+        error!(?ossl_err);
+        JwtError::OpenSSLError
+    })?;
+
+    // Feed in additional data to be checked. Must be called before update.
+    decrypter
+        .aad_update(authenticated_data)
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+    let mut count = decrypter
+        .update(ciphertext, &mut plaintext)
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+    count += decrypter.finalize(&mut plaintext).map_err(|ossl_err| {
+        error!(?ossl_err);
+        JwtError::OpenSSLError
+    })?;
+
+    plaintext.truncate(count);
+
+    Ok(plaintext)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JweA128GCMEncipher;
+    use crate::compact::JweCompact;
+    use crate::crypto::a128kw::JweA128KWEncipher;
+    use crate::traits::*;
+
+    use crate::compact::JweEnc;
+    use crate::jwe::JweBuilder;
+
+    // use base64::{engine::general_purpose, Engine as _};
+    // use std::convert::TryFrom;
+    // use std::str::FromStr;
+
+    #[test]
+    fn a128kw_outer_a128gcm_inner() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let input = vec![1; 128];
+        let jweb = JweBuilder::from(input.clone()).build();
+
+        let jwe_a128kw =
+            JweA128KWEncipher::generate_ephemeral().expect("Unable to build wrap key.");
+
+        let jwe_encrypted = jwe_a128kw
+            .encipher::<JweA128GCMEncipher>(&jweb)
+            .expect("Unable to encrypt.");
+
+        let decrypted = jwe_a128kw
+            .decipher(&jwe_encrypted)
+            .expect("Unable to decrypt.");
+
+        assert_eq!(decrypted.payload(), input);
+    }
+}

--- a/src/crypto/a128gcm.rs
+++ b/src/crypto/a128gcm.rs
@@ -119,7 +119,7 @@ pub(crate) fn aes_gcm_encipher(
     let mut ciphertext = vec![0; plaintext.len() + block_size];
 
     let mut encrypter =
-        Crypter::new(cipher, Mode::Encrypt, aes_key, Some(&iv)).map_err(|ossl_err| {
+        Crypter::new(cipher, Mode::Encrypt, aes_key, Some(iv)).map_err(|ossl_err| {
             error!(?ossl_err);
             JwtError::OpenSSLError
         })?;

--- a/src/crypto/a128gcm.rs
+++ b/src/crypto/a128gcm.rs
@@ -33,6 +33,8 @@ impl TryFrom<&[u8]> for JweA128GCMEncipher {
     }
 }
 
+impl JweEncipherInnerK128 for JweA128GCMEncipher {}
+
 impl JweEncipherInner for JweA128GCMEncipher {
     fn new_ephemeral() -> Result<Self, JwtError> {
         let mut aes_key = [0; KEY_LEN];

--- a/src/crypto/a128kw.rs
+++ b/src/crypto/a128kw.rs
@@ -1,16 +1,10 @@
-use crate::compact::{JweAlg, JweCompact, JweEnc, JweProtectedHeader};
+use crate::compact::{JweAlg, JweCompact, JweProtectedHeader};
 use crate::jwe::Jwe;
 use crate::traits::*;
 use crate::JwtError;
 
-use super::a128cbc_hs256::JweA128CBCHS256Decipher;
-
 use openssl::aes::{unwrap_key, wrap_key, AesKey};
-use openssl::hash::MessageDigest;
-use openssl::pkey::PKey;
 use openssl::rand::rand_bytes;
-use openssl::sign::Signer;
-use openssl::symm::{Cipher, Crypter, Mode};
 
 // Do I need some inner type to handle the enc bit?
 
@@ -20,8 +14,9 @@ pub struct JweA128KWEncipher {
 }
 
 impl JweEncipherOuter for JweA128KWEncipher {
-    fn set_header_alg(&self, hdr: &mut JweProtectedHeader) {
+    fn set_header_alg(&self, hdr: &mut JweProtectedHeader) -> Result<(), JwtError> {
         hdr.alg = JweAlg::A128KW;
+        Ok(())
     }
 
     fn wrap_key(&self, key_to_wrap: &[u8]) -> Result<Vec<u8>, JwtError> {
@@ -99,6 +94,12 @@ impl JweA128KWEncipher {
     }
 }
 
+impl From<[u8; 16]> for JweA128KWEncipher {
+    fn from(wrap_key: [u8; 16]) -> JweA128KWEncipher {
+        JweA128KWEncipher { wrap_key }
+    }
+}
+
 impl TryFrom<Vec<u8>> for JweA128KWEncipher {
     type Error = JwtError;
 
@@ -120,7 +121,6 @@ impl TryFrom<Vec<u8>> for JweA128KWEncipher {
 mod tests {
     use super::JweA128KWEncipher;
     use crate::compact::JweCompact;
-    use crate::traits::*;
     use base64::{engine::general_purpose, Engine as _};
     use std::convert::TryFrom;
     use std::str::FromStr;

--- a/src/crypto/a128kw.rs
+++ b/src/crypto/a128kw.rs
@@ -67,7 +67,7 @@ impl JweA128KWEncipher {
         Ok(JweA128KWEncipher { wrap_key })
     }
 
-    /// Given a JWE, encipher it's content to a compact form.
+    /// Given a JWE, encipher its content to a compact form.
     pub fn encipher<E: JweEncipherInner + JweEncipherInnerK128>(
         &self,
         jwe: &Jwe,
@@ -76,7 +76,7 @@ impl JweA128KWEncipher {
         encipher.encipher_inner(self, jwe)
     }
 
-    /// Given a JWE in compact form, decipher and authenticate it's content.
+    /// Given a JWE in compact form, decipher and authenticate its content.
     pub fn decipher(&self, jwec: &JweCompact) -> Result<Jwe, JwtError> {
         let wrap_key = AesKey::new_decrypt(&self.wrap_key).map_err(|ossl_err| {
             debug!(?ossl_err);

--- a/src/crypto/a128kw.rs
+++ b/src/crypto/a128kw.rs
@@ -45,7 +45,7 @@ impl JweEncipherOuter for JweA128KWEncipher {
         // Algorithm requires extra space.
         let mut wrapped_key = vec![0; key_to_wrap.len() + KW_EXTRA];
 
-        wrap_key(&wrapping_key, None, &mut wrapped_key, &key_to_wrap).map_err(|ossl_err| {
+        wrap_key(&wrapping_key, None, &mut wrapped_key, key_to_wrap).map_err(|ossl_err| {
             debug!(?ossl_err);
             JwtError::OpenSSLError
         })?;

--- a/src/crypto/a128kw.rs
+++ b/src/crypto/a128kw.rs
@@ -1,0 +1,140 @@
+use crate::compact::{JweCompact, JweEnc};
+use crate::JwtError;
+
+use super::a128cbc_hs256::JweA128CBCHS256Decipher;
+
+use openssl::aes::{unwrap_key, AesKey};
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::sign::Signer;
+use openssl::symm::{Cipher, Crypter, Mode};
+
+// Do I need some inner type to handle the enc bit?
+
+#[derive(Clone)]
+pub struct JweA128KWEncipher {
+    wrap_key: [u8; 16],
+}
+
+impl JweA128KWEncipher {
+    pub fn decipher(&self, jwec: &JweCompact) -> Result<Vec<u8>, JwtError> {
+        // From what I can see the cek uses the same IV as the ciphertext?
+        let wrap_key = AesKey::new_decrypt(&self.wrap_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        let mut expected_wrap_key_buffer = match jwec.header.enc {
+            JweEnc::A128GCM => todo!(),
+            JweEnc::A128CBC_HS256 => JweA128CBCHS256Decipher::key_buffer(),
+        };
+
+        let len = unwrap_key(
+            &wrap_key,
+            None,
+            &mut expected_wrap_key_buffer,
+            &jwec.content_enc_key,
+        )
+        .map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        debug!(?len, ?expected_wrap_key_buffer);
+
+        let jwe_decipher = match jwec.header.enc {
+            JweEnc::A128GCM => todo!(),
+            JweEnc::A128CBC_HS256 => {
+                JweA128CBCHS256Decipher::try_from(expected_wrap_key_buffer.as_slice())?
+            }
+        };
+
+        jwe_decipher.decipher_inner(jwec)
+    }
+}
+
+impl TryFrom<Vec<u8>> for JweA128KWEncipher {
+    type Error = JwtError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() != 16 {
+            // Wrong key size.
+            return Err(JwtError::InvalidKey);
+        }
+
+        let mut wrap_key = [0; 16];
+
+        wrap_key.copy_from_slice(&value);
+
+        Ok(JweA128KWEncipher { wrap_key })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JweA128KWEncipher;
+    use crate::compact::JweCompact;
+    use crate::traits::*;
+    use base64::{engine::general_purpose, Engine as _};
+    use std::convert::TryFrom;
+    use std::str::FromStr;
+
+    #[test]
+    fn rfc7516_a128kw_validation_example() {
+        // Taken from https://www.rfc-editor.org/rfc/rfc7516.html#appendix-A.3
+
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let test_jwe = "eyJhbGciOiJBMTI4S1ciLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0.6KB707dM9YTIgHtLvtgWQ8mKwboJW3of9locizkDTHzBC2IlrT1oOQ.AxY8DCtDaGlsbGljb3RoZQ.KDlTtXchhZTGufMYmOYGS4HffxPSUrfmqCHXaI9wOGY.U0m_YmjN04DJvceFICbCVQ";
+        let a128kw_key = general_purpose::URL_SAFE_NO_PAD
+            .decode("GawgguFyGrWKav7AX4VKUg")
+            .expect("Invalid Key");
+
+        let jwec = JweCompact::from_str(test_jwe).unwrap();
+
+        assert!(jwec.to_string() == test_jwe);
+
+        // Check vectors
+        jwec.check_vectors(
+            // Content Encryption Key
+            &[
+                232, 160, 123, 211, 183, 76, 245, 132, 200, 128, 123, 75, 190, 216, 22, 67, 201,
+                138, 193, 186, 9, 91, 122, 31, 246, 90, 28, 139, 57, 3, 76, 124, 193, 11, 98, 37,
+                173, 61, 104, 57,
+            ],
+            // IV
+            &[
+                3, 22, 60, 12, 43, 67, 104, 105, 108, 108, 105, 99, 111, 116, 104, 101,
+            ],
+            // Addition Authenticated Data
+            // &[101, 121, 74, 104, 98, 71, 99, 105, 79, 105, 74, 66, 77, 84, 73, 52, 83, 49, 99, 105, 76, 67, 74, 108, 98, 109, 77, 105, 79, 105, 74, 66, 77, 84, 73, 52, 81, 48, 74, 68, 76, 85, 104, 84, 77, 106, 85, 50, 73, 110, 48],
+            // Cipher Text
+            &[
+                40, 57, 83, 181, 119, 33, 133, 148, 198, 185, 243, 24, 152, 230, 6, 75, 129, 223,
+                127, 19, 210, 82, 183, 230, 168, 33, 215, 104, 143, 112, 56, 102,
+            ],
+            // Authentication Tag
+            &[
+                83, 73, 191, 98, 104, 205, 211, 128, 201, 189, 199, 133, 32, 38, 194, 85,
+            ],
+        );
+
+        assert!(jwec.get_jwk_pubkey_url().is_none());
+        assert!(jwec.get_jwk_pubkey().is_none());
+
+        let a128kw_encipher =
+            JweA128KWEncipher::try_from(a128kw_key).expect("Unable to create encipher");
+
+        let released = a128kw_encipher
+            .decipher(&jwec)
+            .expect("Unable to decipher jwe");
+
+        assert_eq!(
+            released.as_slice(),
+            &[
+                76, 105, 118, 101, 32, 108, 111, 110, 103, 32, 97, 110, 100, 32, 112, 114, 111,
+                115, 112, 101, 114, 46
+            ]
+        );
+    }
+}

--- a/src/crypto/a128kw.rs
+++ b/src/crypto/a128kw.rs
@@ -68,7 +68,10 @@ impl JweA128KWEncipher {
     }
 
     /// Given a JWE, encipher it's content to a compact form.
-    pub fn encipher<E: JweEncipherInner>(&self, jwe: &Jwe) -> Result<JweCompact, JwtError> {
+    pub fn encipher<E: JweEncipherInner + JweEncipherInnerK128>(
+        &self,
+        jwe: &Jwe,
+    ) -> Result<JweCompact, JwtError> {
         let encipher = E::new_ephemeral()?;
         encipher.encipher_inner(self, jwe)
     }

--- a/src/crypto/a256gcm.rs
+++ b/src/crypto/a256gcm.rs
@@ -53,7 +53,7 @@ impl JweEncipherInner for JweA256GCMEncipher {
         let mut header = jwe.header.clone();
         header.enc = JweEnc::A256GCM;
 
-        outer.set_header_alg(&mut header);
+        outer.set_header_alg(&mut header)?;
 
         // Clone the header and update it with our details.
         let hdr_b64 = serde_json::to_vec(&header)

--- a/src/crypto/a256gcm.rs
+++ b/src/crypto/a256gcm.rs
@@ -1,0 +1,144 @@
+use crate::compact::{JweCompact, JweEnc, JweProtectedHeader};
+use crate::jwe::Jwe;
+use crate::traits::*;
+use crate::JwtError;
+
+use openssl::aes::{unwrap_key, AesKey};
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::sign::Signer;
+use openssl::symm::{Cipher, Crypter, Mode};
+
+use base64::{engine::general_purpose, Engine as _};
+use openssl::rand::rand_bytes;
+
+#[derive(Clone)]
+pub struct JweA256GCMEncipher {
+    aes_key: [u8; 32],
+}
+
+impl TryFrom<&[u8]> for JweA256GCMEncipher {
+    type Error = JwtError;
+
+    fn try_from(r_aes_key: &[u8]) -> Result<Self, Self::Error> {
+        if r_aes_key.len() != 32 {
+            return Err(JwtError::InvalidKey);
+        }
+
+        let mut aes_key = [0; 32];
+        aes_key.copy_from_slice(r_aes_key);
+
+        Ok(JweA256GCMEncipher { aes_key })
+    }
+}
+
+impl JweEncipherInner for JweA256GCMEncipher {
+    fn new_ephemeral() -> Result<Self, JwtError> {
+        let mut aes_key = [0; 32];
+        rand_bytes(&mut aes_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        Ok(JweA256GCMEncipher { aes_key })
+    }
+
+    fn encipher_inner<O: JweEncipherOuter>(
+        &self,
+        outer: &O,
+        jwe: &Jwe,
+    ) -> Result<JweCompact, JwtError> {
+        let mut header = jwe.header.clone();
+        header.enc = JweEnc::A256GCM;
+
+        // Clone the header and update it with our details.
+        let hdr_b64 = serde_json::to_vec(&header)
+            .map_err(|e| {
+                debug!(?e);
+                JwtError::InvalidHeaderFormat
+            })
+            .map(|bytes| general_purpose::URL_SAFE_NO_PAD.encode(bytes))?;
+
+        let content_enc_key = outer.wrap_key(&self.aes_key)?;
+
+        // 128 bit iv.
+        let mut iv = vec![0; 16];
+        rand_bytes(&mut iv).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        let authentication_tag_bytes = 16;
+
+        let (ciphertext, authentication_tag) = super::a128gcm::aes_gcm_encipher(
+            Cipher::aes_256_gcm(),
+            authentication_tag_bytes,
+            &jwe.payload,
+            hdr_b64.as_bytes(),
+            &self.aes_key,
+            &iv,
+        )?;
+
+        Ok(JweCompact {
+            header,
+            hdr_b64,
+            content_enc_key,
+            iv,
+            ciphertext,
+            authentication_tag,
+        })
+    }
+}
+
+impl JweA256GCMEncipher {
+    pub fn key_len() -> usize {
+        32
+    }
+
+    pub fn decipher_inner(&self, jwec: &JweCompact) -> Result<Vec<u8>, JwtError> {
+        super::a128gcm::aes_gcm_decipher(
+            Cipher::aes_256_gcm(),
+            &jwec.ciphertext,
+            jwec.hdr_b64.as_bytes(),
+            &self.aes_key,
+            &jwec.iv,
+            &jwec.authentication_tag,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JweA256GCMEncipher;
+    use crate::compact::JweCompact;
+    use crate::crypto::a256kw::JweA256KWEncipher;
+    use crate::traits::*;
+
+    use crate::compact::JweEnc;
+    use crate::jwe::JweBuilder;
+
+    // use base64::{engine::general_purpose, Engine as _};
+    // use std::convert::TryFrom;
+    // use std::str::FromStr;
+
+    #[test]
+    fn a256kw_outer_a256gcm_inner() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let input = vec![1; 256];
+        let jweb = JweBuilder::from(input.clone()).build();
+
+        let jwe_a256kw =
+            JweA256KWEncipher::generate_ephemeral().expect("Unable to build wrap key.");
+
+        let jwe_encrypted = jwe_a256kw
+            .encipher::<JweA256GCMEncipher>(&jweb)
+            .expect("Unable to encrypt.");
+
+        let decrypted = jwe_a256kw
+            .decipher(&jwe_encrypted)
+            .expect("Unable to decrypt.");
+
+        assert_eq!(decrypted.payload(), input);
+    }
+}

--- a/src/crypto/a256gcm.rs
+++ b/src/crypto/a256gcm.rs
@@ -34,6 +34,8 @@ impl TryFrom<&[u8]> for JweA256GCMEncipher {
     }
 }
 
+impl JweEncipherInnerK256 for JweA256GCMEncipher {}
+
 impl JweEncipherInner for JweA256GCMEncipher {
     fn new_ephemeral() -> Result<Self, JwtError> {
         let mut aes_key = [0; KEY_LEN];

--- a/src/crypto/a256gcm.rs
+++ b/src/crypto/a256gcm.rs
@@ -1,13 +1,9 @@
-use crate::compact::{JweCompact, JweEnc, JweProtectedHeader};
+use crate::compact::{JweCompact, JweEnc};
 use crate::jwe::Jwe;
 use crate::traits::*;
 use crate::JwtError;
 
-use openssl::aes::{unwrap_key, AesKey};
-use openssl::hash::MessageDigest;
-use openssl::pkey::PKey;
-use openssl::sign::Signer;
-use openssl::symm::{Cipher, Crypter, Mode};
+use openssl::symm::Cipher;
 
 use base64::{engine::general_purpose, Engine as _};
 use openssl::rand::rand_bytes;
@@ -50,6 +46,8 @@ impl JweEncipherInner for JweA256GCMEncipher {
     ) -> Result<JweCompact, JwtError> {
         let mut header = jwe.header.clone();
         header.enc = JweEnc::A256GCM;
+
+        outer.set_header_alg(&mut header);
 
         // Clone the header and update it with our details.
         let hdr_b64 = serde_json::to_vec(&header)
@@ -110,16 +108,8 @@ impl JweA256GCMEncipher {
 #[cfg(test)]
 mod tests {
     use super::JweA256GCMEncipher;
-    use crate::compact::JweCompact;
     use crate::crypto::a256kw::JweA256KWEncipher;
-    use crate::traits::*;
-
-    use crate::compact::JweEnc;
     use crate::jwe::JweBuilder;
-
-    // use base64::{engine::general_purpose, Engine as _};
-    // use std::convert::TryFrom;
-    // use std::str::FromStr;
 
     #[test]
     fn a256kw_outer_a256gcm_inner() {

--- a/src/crypto/a256kw.rs
+++ b/src/crypto/a256kw.rs
@@ -1,0 +1,115 @@
+use crate::compact::{JweAlg, JweCompact, JweEnc, JweProtectedHeader};
+use crate::jwe::Jwe;
+use crate::traits::*;
+use crate::JwtError;
+
+use openssl::aes::{unwrap_key, wrap_key, AesKey};
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::rand::rand_bytes;
+use openssl::sign::Signer;
+use openssl::symm::{Cipher, Crypter, Mode};
+
+// Do I need some inner type to handle the enc bit?
+
+#[derive(Clone)]
+pub struct JweA256KWEncipher {
+    wrap_key: [u8; 32],
+}
+
+impl JweEncipherOuter for JweA256KWEncipher {
+    fn set_header_alg(&self, hdr: &mut JweProtectedHeader) {
+        hdr.alg = JweAlg::A256KW;
+    }
+
+    fn wrap_key(&self, key_to_wrap: &[u8]) -> Result<Vec<u8>, JwtError> {
+        if key_to_wrap.len() > self.wrap_key.len() {
+            debug!(
+                "Unable to wrap key - key to wrap is longer than the wrapping key {} > {}",
+                key_to_wrap.len(),
+                self.wrap_key.len()
+            );
+            JwtError::InvalidKey;
+        }
+
+        let wrapping_key = AesKey::new_encrypt(&self.wrap_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        // Algorithm requires scratch space.
+        let mut wrapped_key = vec![0; key_to_wrap.len() + 8];
+
+        let len =
+            wrap_key(&wrapping_key, None, &mut wrapped_key, &key_to_wrap).map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })?;
+
+        Ok(wrapped_key)
+    }
+}
+
+impl JweA256KWEncipher {
+    pub fn generate_ephemeral() -> Result<Self, JwtError> {
+        let mut wrap_key = [0; 32];
+
+        rand_bytes(&mut wrap_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        Ok(JweA256KWEncipher { wrap_key })
+    }
+
+    pub fn encipher<E: JweEncipherInner>(&self, jwe: &Jwe) -> Result<JweCompact, JwtError> {
+        let encipher = E::new_ephemeral()?;
+        encipher.encipher_inner(self, jwe)
+    }
+
+    pub fn decipher(&self, jwec: &JweCompact) -> Result<Jwe, JwtError> {
+        let wrap_key = AesKey::new_decrypt(&self.wrap_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        let expected_cek_key_len = jwec.header.enc.key_len();
+        let mut unwrapped_key = vec![0; expected_cek_key_len];
+
+        let len = unwrap_key(&wrap_key, None, &mut unwrapped_key, &jwec.content_enc_key).map_err(
+            |ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            },
+        )?;
+
+        unwrapped_key.truncate(expected_cek_key_len);
+
+        let payload = jwec
+            .header
+            .enc
+            .decipher_inner(unwrapped_key.as_slice(), jwec)?;
+
+        Ok(Jwe {
+            header: jwec.header.clone(),
+            payload,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for JweA256KWEncipher {
+    type Error = JwtError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() != 32 {
+            // Wrong key size.
+            return Err(JwtError::InvalidKey);
+        }
+
+        let mut wrap_key = [0; 32];
+
+        wrap_key.copy_from_slice(&value);
+
+        Ok(JweA256KWEncipher { wrap_key })
+    }
+}

--- a/src/crypto/a256kw.rs
+++ b/src/crypto/a256kw.rs
@@ -1,16 +1,10 @@
-use crate::compact::{JweAlg, JweCompact, JweEnc, JweProtectedHeader};
+use crate::compact::{JweAlg, JweCompact, JweProtectedHeader};
 use crate::jwe::Jwe;
 use crate::traits::*;
 use crate::JwtError;
 
 use openssl::aes::{unwrap_key, wrap_key, AesKey};
-use openssl::hash::MessageDigest;
-use openssl::pkey::PKey;
 use openssl::rand::rand_bytes;
-use openssl::sign::Signer;
-use openssl::symm::{Cipher, Crypter, Mode};
-
-// Do I need some inner type to handle the enc bit?
 
 #[derive(Clone)]
 pub struct JweA256KWEncipher {
@@ -18,8 +12,9 @@ pub struct JweA256KWEncipher {
 }
 
 impl JweEncipherOuter for JweA256KWEncipher {
-    fn set_header_alg(&self, hdr: &mut JweProtectedHeader) {
+    fn set_header_alg(&self, hdr: &mut JweProtectedHeader) -> Result<(), JwtError> {
         hdr.alg = JweAlg::A256KW;
+        Ok(())
     }
 
     fn wrap_key(&self, key_to_wrap: &[u8]) -> Result<Vec<u8>, JwtError> {

--- a/src/crypto/a256kw.rs
+++ b/src/crypto/a256kw.rs
@@ -61,7 +61,7 @@ impl JweA256KWEncipher {
         Ok(JweA256KWEncipher { wrap_key })
     }
 
-    /// Given a JWE, encipher it's content to a compact form.
+    /// Given a JWE, encipher its content to a compact form.
     pub fn encipher<E: JweEncipherInner + JweEncipherInnerK256>(
         &self,
         jwe: &Jwe,
@@ -70,7 +70,7 @@ impl JweA256KWEncipher {
         encipher.encipher_inner(self, jwe)
     }
 
-    /// Given a JWE in compact form, decipher and authenticate it's content.
+    /// Given a JWE in compact form, decipher and authenticate its content.
     pub fn decipher(&self, jwec: &JweCompact) -> Result<Jwe, JwtError> {
         let wrap_key = AesKey::new_decrypt(&self.wrap_key).map_err(|ossl_err| {
             debug!(?ossl_err);

--- a/src/crypto/a256kw.rs
+++ b/src/crypto/a256kw.rs
@@ -62,7 +62,10 @@ impl JweA256KWEncipher {
     }
 
     /// Given a JWE, encipher it's content to a compact form.
-    pub fn encipher<E: JweEncipherInner>(&self, jwe: &Jwe) -> Result<JweCompact, JwtError> {
+    pub fn encipher<E: JweEncipherInner + JweEncipherInnerK256>(
+        &self,
+        jwe: &Jwe,
+    ) -> Result<JweCompact, JwtError> {
         let encipher = E::new_ephemeral()?;
         encipher.encipher_inner(self, jwe)
     }

--- a/src/crypto/a256kw.rs
+++ b/src/crypto/a256kw.rs
@@ -39,7 +39,7 @@ impl JweEncipherOuter for JweA256KWEncipher {
         // Algorithm requires scratch space.
         let mut wrapped_key = vec![0; key_to_wrap.len() + KW_EXTRA];
 
-        wrap_key(&wrapping_key, None, &mut wrapped_key, &key_to_wrap).map_err(|ossl_err| {
+        wrap_key(&wrapping_key, None, &mut wrapped_key, key_to_wrap).map_err(|ossl_err| {
             debug!(?ossl_err);
             JwtError::OpenSSLError
         })?;

--- a/src/crypto/ecdhes_a128kw.rs
+++ b/src/crypto/ecdhes_a128kw.rs
@@ -160,7 +160,7 @@ impl JweEcdhEsA128KWDecipher {
                 let public = ec_key.public_key();
                 let ecgroup = ec_key.group();
 
-                EcKey::from_public_key(&ecgroup, &public)
+                EcKey::from_public_key(ecgroup, public)
             })
             .and_then(|ec_public: EcKey<Public>| PKey::from_ec_key(ec_public))
             .map_err(|ossl_err| {

--- a/src/crypto/ecdhes_a128kw.rs
+++ b/src/crypto/ecdhes_a128kw.rs
@@ -1,0 +1,300 @@
+use crate::compact::{EcCurve, JweAlg, JweCompact, JweEnc, JweProtectedHeader, Jwk};
+use crate::jwe::Jwe;
+use crate::traits::*;
+use crate::JwtError;
+
+use super::a128kw::JweA128KWEncipher;
+
+use base64urlsafedata::Base64UrlSafeData;
+
+use openssl::bn;
+use openssl::ec::{EcGroup, EcKey};
+use openssl::nid::Nid;
+use openssl::pkey::{PKey, PKeyRef, Private, Public};
+use openssl::pkey_ctx::PkeyCtx;
+
+pub struct JweEcdhEsA128KWEncipher {
+    priv_key: PKey<Private>,
+    peer_public_key: PKey<Public>,
+}
+
+impl JweEncipherOuter for JweEcdhEsA128KWEncipher {
+    fn set_header_alg(&self, hdr: &mut JweProtectedHeader) -> Result<(), JwtError> {
+        hdr.alg = JweAlg::ECDH_ES_A128KW;
+
+        // Set epk to the public jwk of the outer encipher here.
+        let ec_key = self.priv_key.ec_key().map_err(|e| {
+            debug!(?e);
+            JwtError::OpenSSLError
+        })?;
+
+        let pkey = ec_key.public_key();
+        let ec_group = ec_key.group();
+
+        let mut bnctx = bn::BigNumContext::new().map_err(|e| {
+            debug!(?e);
+            JwtError::OpenSSLError
+        })?;
+
+        let mut xbn = bn::BigNum::new().map_err(|e| {
+            debug!(?e);
+            JwtError::OpenSSLError
+        })?;
+
+        let mut ybn = bn::BigNum::new().map_err(|e| {
+            debug!(?e);
+            JwtError::OpenSSLError
+        })?;
+
+        pkey.affine_coordinates_gfp(ec_group, &mut xbn, &mut ybn, &mut bnctx)
+            .map_err(|e| {
+                debug!(?e);
+                JwtError::OpenSSLError
+            })?;
+
+        let mut public_key_x = Vec::with_capacity(32);
+        let mut public_key_y = Vec::with_capacity(32);
+
+        public_key_x.resize(32, 0);
+        public_key_y.resize(32, 0);
+
+        let xbnv = xbn.to_vec();
+        let ybnv = ybn.to_vec();
+
+        let (_pad, x_fill) = public_key_x.split_at_mut(32 - xbnv.len());
+        x_fill.copy_from_slice(&xbnv);
+
+        let (_pad, y_fill) = public_key_y.split_at_mut(32 - ybnv.len());
+        y_fill.copy_from_slice(&ybnv);
+
+        hdr.epk = Some(Jwk::EC {
+            crv: EcCurve::P256,
+            x: Base64UrlSafeData(public_key_x),
+            y: Base64UrlSafeData(public_key_y),
+            alg: None,
+            use_: None,
+            kid: None,
+        });
+
+        Ok(())
+    }
+
+    fn wrap_key(&self, key_to_wrap: &[u8]) -> Result<Vec<u8>, JwtError> {
+        if key_to_wrap.len() > 16 {
+            debug!(
+                "Unable to wrap key - key to wrap is longer than the wrapping key {} > {}",
+                key_to_wrap.len(),
+                16
+            );
+            JwtError::InvalidKey;
+        }
+
+        derive_key(&self.priv_key, &self.peer_public_key).and_then(|wrapping_key|
+                // use A128KW with the derived wrap key as usual.
+                JweA128KWEncipher::from(wrapping_key)
+                    .wrap_key(key_to_wrap))
+    }
+}
+
+impl JweEcdhEsA128KWEncipher {
+    pub fn generate_ephemeral(peer_public_key: PKey<Public>) -> Result<Self, JwtError> {
+        // Create a new private key for one-shot derivation to this peer.
+        let ec_key = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)
+            .and_then(|group| EcKey::generate(&group))
+            .map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })?;
+
+        let priv_key = PKey::from_ec_key(ec_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        Ok(JweEcdhEsA128KWEncipher {
+            priv_key,
+            peer_public_key,
+        })
+    }
+
+    pub fn encipher<E: JweEncipherInner>(&self, jwe: &Jwe) -> Result<JweCompact, JwtError> {
+        let encipher = E::new_ephemeral()?;
+        encipher.encipher_inner(self, jwe)
+    }
+}
+
+pub struct JweEcdhEsA128KWDecipher {
+    priv_key: PKey<Private>,
+}
+
+impl JweEcdhEsA128KWDecipher {
+    pub fn generate() -> Result<Self, JwtError> {
+        let ec_key = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)
+            .and_then(|group| EcKey::generate(&group))
+            .map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })?;
+
+        let priv_key = PKey::from_ec_key(ec_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        Ok(JweEcdhEsA128KWDecipher { priv_key })
+    }
+
+    // For transmitting to the other provider.
+    pub fn public_key(&self) -> Result<PKey<Public>, JwtError> {
+        self.priv_key
+            .ec_key()
+            .and_then(|ec_key| {
+                let public = ec_key.public_key();
+                let ecgroup = ec_key.group();
+
+                EcKey::from_public_key(&ecgroup, &public)
+            })
+            .and_then(|ec_public: EcKey<Public>| PKey::from_ec_key(ec_public))
+            .map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })
+    }
+
+    pub fn decipher(&self, jwec: &JweCompact) -> Result<Jwe, JwtError> {
+        // Derive the shared secret from our private key + the JWE header public key.
+
+        // Get the epk - if not set, error.
+        let Some(epk_jwk) = &jwec.header.epk else {
+            error!("epk not found in header, unable to proceed");
+            return Err(JwtError::CriticalMissingHeaderValue);
+        };
+
+        let ephemeral_public_key = match epk_jwk {
+            Jwk::EC {
+                crv: EcCurve::P256,
+                x,
+                y,
+                alg: _,
+                use_: _,
+                kid: _,
+            } => {
+                let curve = Nid::X9_62_PRIME256V1;
+                let ec_group = EcGroup::from_curve_name(curve).map_err(|e| {
+                    debug!(?e);
+                    JwtError::OpenSSLError
+                })?;
+
+                let xbn = bn::BigNum::from_slice(&x.0).map_err(|e| {
+                    debug!(?e);
+                    JwtError::OpenSSLError
+                })?;
+                let ybn = bn::BigNum::from_slice(&y.0).map_err(|e| {
+                    debug!(?e);
+                    JwtError::OpenSSLError
+                })?;
+
+                let ec_pkey = EcKey::from_public_key_affine_coordinates(&ec_group, &xbn, &ybn)
+                    .map_err(|e| {
+                        debug!(?e);
+                        JwtError::OpenSSLError
+                    })?;
+
+                ec_pkey.check_key().map_err(|e| {
+                    debug!(?e);
+                    JwtError::OpenSSLError
+                })?;
+
+                PKey::from_ec_key(ec_pkey).map_err(|e| {
+                    debug!(?e);
+                    JwtError::OpenSSLError
+                })?
+            }
+            _ => {
+                error!("Invalid JWK in epk");
+                return Err(JwtError::InvalidKey);
+            }
+        };
+
+        derive_key(&self.priv_key, &ephemeral_public_key).and_then(|wrapping_key|
+                // use A128KW with the derived wrap key as usual.
+                JweA128KWEncipher::from(wrapping_key)
+                    .decipher(jwec))
+    }
+}
+
+fn derive_key(
+    priv_key: &PKeyRef<Private>,
+    pub_key: &PKeyRef<Public>,
+) -> Result<[u8; 16], JwtError> {
+    // derive the wrap key.
+    let mut priv_key_ctx = PkeyCtx::new(priv_key).map_err(|ossl_err| {
+        debug!(?ossl_err);
+        JwtError::OpenSSLError
+    })?;
+
+    priv_key_ctx.derive_init().map_err(|ossl_err| {
+        debug!(?ossl_err);
+        JwtError::OpenSSLError
+    })?;
+
+    priv_key_ctx.derive_set_peer(pub_key).map_err(|ossl_err| {
+        debug!(?ossl_err);
+        JwtError::OpenSSLError
+    })?;
+
+    let mut wrapping_key = [0; 16];
+
+    priv_key_ctx
+        .derive(Some(&mut wrapping_key))
+        .map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+    Ok(wrapping_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JweEcdhEsA128KWDecipher, JweEcdhEsA128KWEncipher};
+    use crate::compact::JweCompact;
+    use crate::crypto::a128gcm::JweA128GCMEncipher;
+    use crate::traits::*;
+
+    use crate::compact::JweEnc;
+    use crate::jwe::JweBuilder;
+
+    // use base64::{engine::general_purpose, Engine as _};
+    // use std::convert::TryFrom;
+    // use std::str::FromStr;
+
+    #[test]
+    fn ecdh_a128kw_outer_a128gcm_inner() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let input = vec![1; 256];
+        let jweb = JweBuilder::from(input.clone()).build();
+
+        // Create a new decipher from a private key.
+
+        let jwe_ecds_a128_de =
+            JweEcdhEsA128KWDecipher::generate().expect("Unable to create ecdh es128 decipher");
+
+        let public_key = jwe_ecds_a128_de.public_key().unwrap();
+
+        let jwe_ecds_a128_en = JweEcdhEsA128KWEncipher::generate_ephemeral(public_key)
+            .expect("Unable to build wrap key.");
+
+        let jwe_encrypted = jwe_ecds_a128_en
+            .encipher::<JweA128GCMEncipher>(&jweb)
+            .expect("Unable to encrypt.");
+
+        // Decrypt with the partner.
+        let decrypted = jwe_ecds_a128_de
+            .decipher(&jwe_encrypted)
+            .expect("Unable to decrypt.");
+
+        assert_eq!(decrypted.payload(), input);
+    }
+}

--- a/src/crypto/ecdhes_a128kw.rs
+++ b/src/crypto/ecdhes_a128kw.rs
@@ -119,7 +119,7 @@ impl JweEcdhEsA128KWEncipher {
         })
     }
 
-    /// Given a JWE, encipher it's content to a compact form.
+    /// Given a JWE, encipher its content to a compact form.
     pub fn encipher<E: JweEncipherInner + JweEncipherInnerK128>(
         &self,
         jwe: &Jwe,
@@ -155,7 +155,7 @@ impl JweEcdhEsA128KWDecipher {
     }
 
     /// Retrieve the public key of this decipher. This should be sent to the encipher
-    /// to use with it's ephemeral key for key agreement
+    /// to use with its ephemeral key for key agreement
     pub fn public_key(&self) -> Result<PKey<Public>, JwtError> {
         self.priv_key
             .ec_key()
@@ -172,7 +172,7 @@ impl JweEcdhEsA128KWDecipher {
             })
     }
 
-    /// Given a JWE in compact form, decipher and authenticate it's content.
+    /// Given a JWE in compact form, decipher and authenticate its content.
     pub fn decipher(&self, jwec: &JweCompact) -> Result<Jwe, JwtError> {
         // Derive the shared secret from our private key + the JWE header public key.
 

--- a/src/crypto/ecdhes_a128kw.rs
+++ b/src/crypto/ecdhes_a128kw.rs
@@ -120,7 +120,10 @@ impl JweEcdhEsA128KWEncipher {
     }
 
     /// Given a JWE, encipher it's content to a compact form.
-    pub fn encipher<E: JweEncipherInner>(&self, jwe: &Jwe) -> Result<JweCompact, JwtError> {
+    pub fn encipher<E: JweEncipherInner + JweEncipherInnerK128>(
+        &self,
+        jwe: &Jwe,
+    ) -> Result<JweCompact, JwtError> {
         let encipher = E::new_ephemeral()?;
         encipher.encipher_inner(self, jwe)
     }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -4,12 +4,17 @@ use crate::error::JwtError;
 use base64::{engine::general_purpose, Engine as _};
 use openssl::x509::X509;
 
-use crate::compact::JwsCompact;
+use crate::compact::{JweCompact, JwsCompact};
 
 mod es256;
 mod hs256;
 mod rs256;
 mod x509;
+
+// mod rsaes_oaep;
+
+mod a128cbc_hs256;
+mod a128kw;
 
 #[cfg(feature = "hsm-crypto")]
 mod tpm;
@@ -56,5 +61,21 @@ impl JwsCompact {
         let fullchain = fullchain?;
 
         Ok(Some(fullchain))
+    }
+}
+
+impl JweCompact {
+    #[cfg(test)]
+    fn check_vectors(
+        &self,
+        chk_cek: &[u8],
+        chk_iv: &[u8],
+        chk_cipher: &[u8],
+        chk_aad: &[u8],
+    ) -> bool {
+        chk_cek == &self.content_enc_key
+            && chk_iv == &self.iv
+            && chk_cipher == &self.ciphertext
+            && chk_aad == &self.authentication_tag
     }
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -29,9 +29,9 @@ pub use hs256::JwsHs256Signer;
 pub use rs256::{JwsRs256Signer, JwsRs256Verifier};
 pub use x509::{JwsX509Verifier, JwsX509VerifierBuilder};
 
-pub use ecdhes_a128kw::{JweEcdhEsA128KWEncipher, JweEcdhEsA128KWDecipher};
 pub use a128kw::JweA128KWEncipher;
 pub use a256kw::JweA256KWEncipher;
+pub use ecdhes_a128kw::{JweEcdhEsA128KWDecipher, JweEcdhEsA128KWEncipher};
 pub use rsaes_oaep::JweRSAOAEPDecipher;
 
 #[cfg(feature = "hsm-crypto")]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -19,6 +19,8 @@ mod a128kw;
 mod a256gcm;
 mod a256kw;
 
+mod ecdhes_a128kw;
+
 #[cfg(feature = "hsm-crypto")]
 mod tpm;
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -75,7 +75,7 @@ impl JwsCompact {
 }
 
 impl JweEnc {
-    pub(crate) fn key_len(&self) -> usize {
+    pub(crate) fn key_len(self) -> usize {
         match self {
             JweEnc::A128GCM => a128gcm::JweA128GCMEncipher::key_len(),
             JweEnc::A256GCM => a256gcm::JweA256GCMEncipher::key_len(),
@@ -84,7 +84,7 @@ impl JweEnc {
     }
 
     pub(crate) fn decipher_inner(
-        &self,
+        self,
         key_buffer: &[u8],
         jwec: &JweCompact,
     ) -> Result<Vec<u8>, JwtError> {

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -29,6 +29,11 @@ pub use hs256::JwsHs256Signer;
 pub use rs256::{JwsRs256Signer, JwsRs256Verifier};
 pub use x509::{JwsX509Verifier, JwsX509VerifierBuilder};
 
+pub use ecdhes_a128kw::{JweEcdhEsA128KWEncipher, JweEcdhEsA128KWDecipher};
+pub use a128kw::JweA128KWEncipher;
+pub use a256kw::JweA256KWEncipher;
+pub use rsaes_oaep::JweRSAOAEPDecipher;
+
 #[cfg(feature = "hsm-crypto")]
 pub use tpm::JwsTpmSigner;
 

--- a/src/crypto/rsaes_oaep.rs
+++ b/src/crypto/rsaes_oaep.rs
@@ -8,6 +8,9 @@ use openssl::pkey::PKey;
 use openssl::pkey::Private;
 use openssl::rsa::{Padding, Rsa};
 
+/// A JWE outer decipher for RSA-OAEP. This type can only decipher - it can not
+/// create new enciphered JWEs. You should use [JweEcdhEsA128KWEncipher] or
+/// [JweA128KWEncipher]
 pub struct JweRSAOAEPDecipher {
     rsa_priv_key: PKey<Private>,
 }
@@ -26,6 +29,7 @@ impl TryFrom<Rsa<Private>> for JweRSAOAEPDecipher {
 }
 
 impl JweRSAOAEPDecipher {
+    /// Given a JWE in compact form, decipher and authenticate it's content.
     pub fn decipher(&self, jwec: &JweCompact) -> Result<Jwe, JwtError> {
         let expected_wrap_key_buffer_len = jwec.header.enc.key_len();
 

--- a/src/crypto/rsaes_oaep.rs
+++ b/src/crypto/rsaes_oaep.rs
@@ -29,7 +29,7 @@ impl TryFrom<Rsa<Private>> for JweRSAOAEPDecipher {
 }
 
 impl JweRSAOAEPDecipher {
-    /// Given a JWE in compact form, decipher and authenticate it's content.
+    /// Given a JWE in compact form, decipher and authenticate its content.
     pub fn decipher(&self, jwec: &JweCompact) -> Result<Jwe, JwtError> {
         let expected_wrap_key_buffer_len = jwec.header.enc.key_len();
 

--- a/src/crypto/rsaes_oaep.rs
+++ b/src/crypto/rsaes_oaep.rs
@@ -1,0 +1,243 @@
+use crate::compact::{JweCompact, JweEnc};
+use crate::jwe::Jwe;
+use crate::JwtError;
+
+use super::a128cbc_hs256::JweA128CBCHS256Decipher;
+use super::a256gcm::JweA256GCMEncipher;
+
+use openssl::encrypt::Decrypter;
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::pkey::Private;
+use openssl::rsa::{Padding, Rsa};
+
+pub struct JweRSAOAEPDecipher {
+    rsa_priv_key: PKey<Private>,
+}
+
+impl TryFrom<Rsa<Private>> for JweRSAOAEPDecipher {
+    type Error = JwtError;
+
+    fn try_from(value: Rsa<Private>) -> Result<Self, Self::Error> {
+        let rsa_priv_key = PKey::from_rsa(value).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        Ok(JweRSAOAEPDecipher { rsa_priv_key })
+    }
+}
+
+impl JweRSAOAEPDecipher {
+    pub fn decipher(&self, jwec: &JweCompact) -> Result<Jwe, JwtError> {
+        let expected_wrap_key_buffer_len = jwec.header.enc.key_len();
+
+        // Decrypt cek
+        let mut wrap_key_decrypter = Decrypter::new(&self.rsa_priv_key).map_err(|ossl_err| {
+            debug!(?ossl_err);
+            JwtError::OpenSSLError
+        })?;
+
+        wrap_key_decrypter
+            .set_rsa_padding(Padding::PKCS1_OAEP)
+            .map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })?;
+
+        wrap_key_decrypter
+            .set_rsa_mgf1_md(MessageDigest::sha1())
+            .map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })?;
+
+        wrap_key_decrypter
+            .set_rsa_oaep_md(MessageDigest::sha1())
+            .map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })?;
+
+        // Rsa oaep will often work on bigger block sizes, so we need a larger buffer and then we can copy.
+        let buf_len = wrap_key_decrypter
+            .decrypt_len(&jwec.content_enc_key)
+            .map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })?;
+
+        let mut unwrapped_key = vec![0; buf_len];
+
+        wrap_key_decrypter
+            .decrypt(&jwec.content_enc_key, &mut unwrapped_key)
+            .map_err(|ossl_err| {
+                debug!(?ossl_err);
+                JwtError::OpenSSLError
+            })?;
+
+        unwrapped_key.truncate(expected_wrap_key_buffer_len);
+
+        let payload = jwec
+            .header
+            .enc
+            .decipher_inner(unwrapped_key.as_slice(), jwec)?;
+
+        Ok(Jwe {
+            header: jwec.header.clone(),
+            payload,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JweRSAOAEPDecipher;
+    use crate::compact::JweCompact;
+    use crate::traits::*;
+    use base64::{engine::general_purpose, Engine as _};
+    use std::convert::TryFrom;
+    use std::str::FromStr;
+
+    use openssl::bn;
+    use openssl::pkey::Private;
+    use openssl::rsa::Rsa;
+
+    fn rsa_from_private_components(
+        n: &str,
+        e: &str,
+        d: &str,
+        p: &str,
+        q: &str,
+        dmp1: &str,
+        dmq1: &str,
+        iqmp: &str,
+    ) -> Rsa<Private> {
+        let n = general_purpose::URL_SAFE_NO_PAD
+            .decode(n)
+            .expect("Invalid Key");
+
+        let e = general_purpose::URL_SAFE_NO_PAD
+            .decode(e)
+            .expect("Invalid Key");
+
+        let d = general_purpose::URL_SAFE_NO_PAD
+            .decode(d)
+            .expect("Invalid Key");
+
+        let p = general_purpose::URL_SAFE_NO_PAD
+            .decode(p)
+            .expect("Invalid Key");
+
+        let q = general_purpose::URL_SAFE_NO_PAD
+            .decode(q)
+            .expect("Invalid Key");
+
+        let dmp1 = general_purpose::URL_SAFE_NO_PAD
+            .decode(dmp1)
+            .expect("Invalid Key");
+
+        let dmq1 = general_purpose::URL_SAFE_NO_PAD
+            .decode(dmq1)
+            .expect("Invalid Key");
+
+        let iqmp = general_purpose::URL_SAFE_NO_PAD
+            .decode(iqmp)
+            .expect("Invalid Key");
+
+        let nbn = bn::BigNum::from_slice(&n).expect("Invalid bignumber");
+        let ebn = bn::BigNum::from_slice(&e).expect("Invalid bignumber");
+        let dbn = bn::BigNum::from_slice(&d).expect("Invalid bignumber");
+        let pbn = bn::BigNum::from_slice(&p).expect("Invalid bignumber");
+        let qbn = bn::BigNum::from_slice(&q).expect("Invalid bignumber");
+
+        let dpbn = bn::BigNum::from_slice(&dmp1).expect("Invalid bignumber");
+        let dqbn = bn::BigNum::from_slice(&dmq1).expect("Invalid bignumber");
+        let dibn = bn::BigNum::from_slice(&iqmp).expect("Invalid bignumber");
+
+        Rsa::from_private_components(nbn, ebn, dbn, pbn, qbn, dpbn, dqbn, dibn)
+            .expect("Invalid parameters")
+    }
+
+    #[test]
+    fn rfc7516_rsa_oaep_validation_example() {
+        // Taken from https://www.rfc-editor.org/rfc/rfc7516.html#appendix-A.3
+
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let test_jwe = "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDbSv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi6UklfCpIMfIjf7iGdXKHzg.48V1_ALb6US04U3b.5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A.XFBoMYUZodetZdvTiFvSkQ";
+
+        let rsa_priv_key = rsa_from_private_components(
+"oahUIoWw0K0usKNuOR6H4wkf4oBUXHTxRvgb48E-BVvxkeDNjbC4he8rUWcJoZmds2h7M70imEVhRU5djINXtqllXI4DFqcI1DgjT9LewND8MW2Krf3Spsk_ZkoFnilakGygTwpZ3uesH-PFABNIUYpOiN15dsQRkgr0vEhxN92i2asbOenSZeyaxziK72UwxrrKoExv6kc5twXTq4h-QChLOln0_mtUZwfsRaMStPs6mS6XrgxnxbWhojf663tuEQueGC-FCMfra36C9knDFGzKsNa7LZK2djYgyD3JR_MB_4NUJW_TqOQtwHYbxevoJArm-L5StowjzGy-_bq6Gw",
+"AQAB",
+"kLdtIj6GbDks_ApCSTYQtelcNttlKiOyPzMrXHeI-yk1F7-kpDxY4-WY5NWV5KntaEeXS1j82E375xxhWMHXyvjYecPT9fpwR_M9gV8n9Hrh2anTpTD93Dt62ypW3yDsJzBnTnrYu1iwWRgBKrEYY46qAZIrA2xAwnm2X7uGR1hghkqDp0Vqj3kbSCz1XyfCs6_LehBwtxHIyh8Ripy40p24moOAbgxVw3rxT_vlt3UVe4WO3JkJOzlpUf-KTVI2Ptgm-dARxTEtE-id-4OJr0h-K-VFs3VSndVTIznSxfyrj8ILL6MG_Uv8YAu7VILSB3lOW085-4qE3DzgrTjgyQ",
+"1r52Xk46c-LsfB5P442p7atdPUrxQSy4mti_tZI3Mgf2EuFVbUoDBvaRQ-SWxkbkmoEzL7JXroSBjSrK3YIQgYdMgyAEPTPjXv_hI2_1eTSPVZfzL0lffNn03IXqWF5MDFuoUYE0hzb2vhrlN_rKrbfDIwUbTrjjgieRbwC6Cl0",
+"wLb35x7hmQWZsWJmB_vle87ihgZ19S8lBEROLIsZG4ayZVe9Hi9gDVCOBmUDdaDYVTSNx_8Fyw1YYa9XGrGnDew00J28cRUoeBB_jKI1oma0Orv1T9aXIWxKwd4gvxFImOWr3QRL9KEBRzk2RatUBnmDZJTIAfwTs0g68UZHvtc",
+"ZK-YwE7diUh0qR1tR7w8WHtolDx3MZ_OTowiFvgfeQ3SiresXjm9gZ5KLhMXvo-uz-KUJWDxS5pFQ_M0evdo1dKiRTjVw_x4NyqyXPM5nULPkcpU827rnpZzAJKpdhWAgqrXGKAECQH0Xt4taznjnd_zVpAmZZq60WPMBMfKcuE",
+"Dq0gfgJ1DdFGXiLvQEZnuKEN0UUmsJBxkjydc3j4ZYdBiMRAy86x0vHCjywcMlYYg4yoC4YZa9hNVcsjqA3FeiL19rk8g6Qn29Tt0cj8qqyFpz9vNDBUfCAiJVeESOjJDZPYHdHY8v1b-o-Z2X5tvLx-TCekf7oxyeKDUqKWjis",
+"VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
+);
+
+        // Check key parameters
+        assert!(rsa_priv_key.check_key().unwrap());
+
+        let jwec = JweCompact::from_str(test_jwe).unwrap();
+
+        assert!(jwec.to_string() == test_jwe);
+
+        // Check vectors
+        jwec.check_vectors(
+            // Content Encryption Key
+            &[
+                56, 163, 154, 192, 58, 53, 222, 4, 105, 218, 136, 218, 29, 94, 203, 22, 150, 92,
+                129, 94, 211, 232, 53, 89, 41, 60, 138, 56, 196, 216, 82, 98, 168, 76, 37, 73, 70,
+                7, 36, 8, 191, 100, 136, 196, 244, 220, 145, 158, 138, 155, 4, 117, 141, 230, 199,
+                247, 173, 45, 182, 214, 74, 177, 107, 211, 153, 11, 205, 196, 171, 226, 162, 128,
+                171, 182, 13, 237, 239, 99, 193, 4, 91, 219, 121, 223, 107, 167, 61, 119, 228, 173,
+                156, 137, 134, 200, 80, 219, 74, 253, 56, 185, 91, 177, 34, 158, 89, 154, 205, 96,
+                55, 18, 138, 43, 96, 218, 215, 128, 124, 75, 138, 243, 85, 25, 109, 117, 140, 26,
+                155, 249, 67, 167, 149, 231, 100, 6, 41, 65, 214, 251, 232, 87, 72, 40, 182, 149,
+                154, 168, 31, 193, 126, 215, 89, 28, 111, 219, 125, 182, 139, 235, 195, 197, 23,
+                234, 55, 58, 63, 180, 68, 202, 206, 149, 75, 205, 248, 176, 67, 39, 178, 60, 98,
+                193, 32, 238, 122, 96, 158, 222, 57, 183, 111, 210, 55, 188, 215, 206, 180, 166,
+                150, 166, 106, 250, 55, 229, 72, 40, 69, 214, 216, 104, 23, 40, 135, 212, 28, 127,
+                41, 80, 175, 174, 168, 115, 171, 197, 89, 116, 92, 103, 246, 83, 216, 182, 176, 84,
+                37, 147, 35, 45, 219, 172, 99, 226, 233, 73, 37, 124, 42, 72, 49, 242, 35, 127,
+                184, 134, 117, 114, 135, 206,
+            ],
+            // IV
+            &[227, 197, 117, 252, 2, 219, 233, 68, 180, 225, 77, 219],
+            // Cipher Text
+            &[
+                229, 236, 166, 241, 53, 191, 115, 196, 174, 43, 73, 109, 39, 122, 233, 96, 140,
+                206, 120, 52, 51, 237, 48, 11, 190, 219, 186, 80, 111, 104, 50, 142, 47, 167, 59,
+                61, 181, 127, 196, 21, 40, 82, 242, 32, 123, 143, 168, 226, 73, 216, 176, 144, 138,
+                247, 106, 60, 16, 205, 160, 109, 64, 63, 192,
+            ],
+            // Authentication Tag
+            &[
+                92, 80, 104, 49, 133, 25, 161, 215, 173, 101, 219, 211, 136, 91, 210, 145,
+            ],
+        );
+
+        assert!(jwec.get_jwk_pubkey_url().is_none());
+        assert!(jwec.get_jwk_pubkey().is_none());
+
+        let rsa_oaep_decipher =
+            JweRSAOAEPDecipher::try_from(rsa_priv_key).expect("Unable to create decipher");
+
+        let released = rsa_oaep_decipher
+            .decipher(&jwec)
+            .expect("Unable to decipher jwe");
+
+        assert_eq!(
+            released.payload(),
+            &[
+                84, 104, 101, 32, 116, 114, 117, 101, 32, 115, 105, 103, 110, 32, 111, 102, 32,
+                105, 110, 116, 101, 108, 108, 105, 103, 101, 110, 99, 101, 32, 105, 115, 32, 110,
+                111, 116, 32, 107, 110, 111, 119, 108, 101, 100, 103, 101, 32, 98, 117, 116, 32,
+                105, 109, 97, 103, 105, 110, 97, 116, 105, 111, 110, 46
+            ]
+        );
+    }
+}

--- a/src/crypto/rsaes_oaep.rs
+++ b/src/crypto/rsaes_oaep.rs
@@ -1,9 +1,6 @@
-use crate::compact::{JweCompact, JweEnc};
+use crate::compact::JweCompact;
 use crate::jwe::Jwe;
 use crate::JwtError;
-
-use super::a128cbc_hs256::JweA128CBCHS256Decipher;
-use super::a256gcm::JweA256GCMEncipher;
 
 use openssl::encrypt::Decrypter;
 use openssl::hash::MessageDigest;
@@ -94,7 +91,6 @@ impl JweRSAOAEPDecipher {
 mod tests {
     use super::JweRSAOAEPDecipher;
     use crate::compact::JweCompact;
-    use crate::traits::*;
     use base64::{engine::general_purpose, Engine as _};
     use std::convert::TryFrom;
     use std::str::FromStr;

--- a/src/crypto/rsaes_oaep.rs
+++ b/src/crypto/rsaes_oaep.rs
@@ -9,8 +9,8 @@ use openssl::pkey::Private;
 use openssl::rsa::{Padding, Rsa};
 
 /// A JWE outer decipher for RSA-OAEP. This type can only decipher - it can not
-/// create new enciphered JWEs. You should use [JweEcdhEsA128KWEncipher] or
-/// [JweA128KWEncipher]
+/// create new enciphered JWEs. You should use [crate::crypto::JweEcdhEsA128KWEncipher] or
+/// [crate::crypto::JweA128KWEncipher]
 pub struct JweRSAOAEPDecipher {
     rsa_priv_key: PKey<Private>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,8 @@ pub enum JwtError {
     X5cChainNotTrusted,
     /// The provided key was not valid
     InvalidKey,
+    /// A required header value is not set
+    CriticalMissingHeaderValue,
 }
 
 impl fmt::Display for JwtError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,8 @@ pub enum JwtError {
     X5cChainMissingLeaf,
     /// The provided x5c chain is not trusted
     X5cChainNotTrusted,
+    /// The provided key was not valid
+    InvalidKey,
 }
 
 impl fmt::Display for JwtError {

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -3,6 +3,7 @@
 use crate::compact::JweProtectedHeader;
 use serde::{Deserialize, Serialize};
 
+/// A builder to create a new JWS that can be enciphered.
 pub struct JweBuilder {
     pub(crate) header: JweProtectedHeader,
     pub(crate) payload: Vec<u8>,

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -64,12 +64,6 @@ impl Jwe {
     pub fn from_json<'a, T: Deserialize<'a>>(&'a self) -> Result<T, serde_json::Error> {
         serde_json::from_slice(self.payload())
     }
-
-    /*
-    pub(crate) fn set_typ(&mut self, typ: Option<&str>) {
-        self.header.typ = typ.map(|s| s.to_string());
-    }
-    */
 }
 
 #[cfg(all(feature = "openssl", test))]

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -1,0 +1,12 @@
+#[cfg(all(feature = "openssl", test))]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Default, Debug, Serialize, Clone, Deserialize, PartialEq)]
+    struct CustomExtension {
+        my_exten: String,
+    }
+
+    #[test]
+    fn test_encrypt_and_decrypt() {}
+}

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -1,3 +1,76 @@
+//! JWE Implementation
+
+use crate::compact::JweProtectedHeader;
+use serde::{Deserialize, Serialize};
+
+pub struct JweBuilder {
+    pub(crate) header: JweProtectedHeader,
+    pub(crate) payload: Vec<u8>,
+}
+
+impl From<Vec<u8>> for JweBuilder {
+    fn from(payload: Vec<u8>) -> Self {
+        JweBuilder {
+            header: JweProtectedHeader::default(),
+            payload,
+        }
+    }
+}
+
+impl JweBuilder {
+    /// Set the content type of this JWE
+    pub fn set_typ(mut self, typ: Option<&str>) -> Self {
+        self.header.typ = typ.map(|s| s.to_string());
+        self
+    }
+
+    /// Set the content type of the payload
+    pub fn set_cty(mut self, cty: Option<&str>) -> Self {
+        self.header.cty = cty.map(|s| s.to_string());
+        self
+    }
+
+    /// Finalise this builder
+    pub fn build(self) -> Jwe {
+        let JweBuilder { header, payload } = self;
+        Jwe { header, payload }
+    }
+}
+
+/// A Jws that is being created or has succeeded in being validated
+#[derive(Debug, Clone, PartialEq)]
+pub struct Jwe {
+    pub(crate) header: JweProtectedHeader,
+    pub(crate) payload: Vec<u8>,
+}
+
+impl Jwe {
+    /// Get the bytes of the payload of this JWS
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    /// Create a JWE from a serialisable type. This assumes you want to encode
+    /// the input value with json.
+    pub fn into_json<T: Serialize>(value: &T) -> Result<Jwe, serde_json::Error> {
+        serde_json::to_vec(value).map(|payload| Jwe {
+            header: JweProtectedHeader::default(),
+            payload,
+        })
+    }
+
+    /// Deserialise the inner payload of this JWE assuming it contains json.
+    pub fn from_json<'a, T: Deserialize<'a>>(&'a self) -> Result<T, serde_json::Error> {
+        serde_json::from_slice(self.payload())
+    }
+
+    /*
+    pub(crate) fn set_typ(&mut self, typ: Option<&str>) {
+        self.header.typ = typ.map(|s| s.to_string());
+    }
+    */
+}
+
 #[cfg(all(feature = "openssl", test))]
 mod tests {
     use serde::{Deserialize, Serialize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-// #![deny(warnings)]
-// #![warn(missing_docs)]
+#![deny(warnings)]
+#![warn(missing_docs)]
 
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // #![deny(warnings)]
+// #![warn(missing_docs)]
 
 #![warn(unused_extern_crates)]
-#![warn(missing_docs)]
 #![forbid(unsafe_code)]
 // Enable some groups of clippy lints.
 #![deny(clippy::suspicious)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#![deny(warnings)]
+// #![deny(warnings)]
+
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
@@ -110,6 +111,7 @@ pub mod compact;
 pub mod traits;
 
 pub mod error;
+pub mod jwe;
 pub mod jws;
 pub mod jwt;
 pub mod oidc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(warnings)]
 #![warn(missing_docs)]
-
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 // Enable some groups of clippy lints.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -109,7 +109,7 @@ pub trait JweEncipherInnerK256 {}
 /// A trait defining types that provide inner content encryption
 pub trait JweEncipherInner {
     /// Generate a new ephemeral key for this inner encipher. Keys are always
-    /// ephemeral with inner types as they are "once use" only.
+    /// ephemeral with inner types as they are "one use" only.
     fn new_ephemeral() -> Result<Self, JwtError>
     where
         Self: Sized;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -92,7 +92,7 @@ pub trait JwsSignable {
 }
 
 pub(crate) trait JweEncipherOuter {
-    fn set_header_alg(&self, hdr: &mut JweProtectedHeader);
+    fn set_header_alg(&self, hdr: &mut JweProtectedHeader) -> Result<(), JwtError>;
 
     fn wrap_key(&self, key_to_wrap: &[u8]) -> Result<Vec<u8>, JwtError>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -91,17 +91,24 @@ pub trait JwsSignable {
     fn post_process(&self, value: JwsCompact) -> Result<Self::Signed, JwtError>;
 }
 
-pub(crate) trait JweEncipherOuter {
+/// A trait defining types that provide outer content encryption key wrapping.
+pub trait JweEncipherOuter {
+    /// Given a protected header, set the algorithm used by this outer key wrap
     fn set_header_alg(&self, hdr: &mut JweProtectedHeader) -> Result<(), JwtError>;
 
+    /// Wrap the provided ephemeral key
     fn wrap_key(&self, key_to_wrap: &[u8]) -> Result<Vec<u8>, JwtError>;
 }
 
+/// A trait defining types that provide inner content encryption
 pub trait JweEncipherInner {
+    /// Generate a new ephemeral key for this inner encipher. Keys are always
+    /// ephemeral with inner types as they are "once use" only.
     fn new_ephemeral() -> Result<Self, JwtError>
     where
         Self: Sized;
 
+    /// Encipher the inner content of a jwe
     fn encipher_inner<O: JweEncipherOuter>(
         &self,
         outer: &O,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -100,6 +100,12 @@ pub trait JweEncipherOuter {
     fn wrap_key(&self, key_to_wrap: &[u8]) -> Result<Vec<u8>, JwtError>;
 }
 
+/// A marker trait indicating that this type uses 128 bit keys.
+pub trait JweEncipherInnerK128 {}
+
+/// A marker trait indicating that this type uses 256 bit keys.
+pub trait JweEncipherInnerK256 {}
+
 /// A trait defining types that provide inner content encryption
 pub trait JweEncipherInner {
     /// Generate a new ephemeral key for this inner encipher. Keys are always

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,9 @@
 //! Traits that define behaviour of JWS signing and verification types.
 
+use crate::compact::{JweCompact, JweProtectedHeader};
 use crate::compact::{JwsCompact, JwsCompactVerifyData, ProtectedHeader};
 use crate::error::JwtError;
+use crate::jwe::Jwe;
 use crate::jws::{Jws, JwsCompactSign2Data};
 
 /// A trait defining how a JwsSigner will operate.
@@ -87,4 +89,22 @@ pub trait JwsSignable {
 
     /// After the signature is complete, allow post-processing of the compact jws
     fn post_process(&self, value: JwsCompact) -> Result<Self::Signed, JwtError>;
+}
+
+pub(crate) trait JweEncipherOuter {
+    fn set_header_alg(&self, hdr: &mut JweProtectedHeader);
+
+    fn wrap_key(&self, key_to_wrap: &[u8]) -> Result<Vec<u8>, JwtError>;
+}
+
+pub trait JweEncipherInner {
+    fn new_ephemeral() -> Result<Self, JwtError>
+    where
+        Self: Sized;
+
+    fn encipher_inner<O: JweEncipherOuter>(
+        &self,
+        outer: &O,
+        jwe: &Jwe,
+    ) -> Result<JweCompact, JwtError>;
 }


### PR DESCRIPTION
Implements compact jwe - this is needed for upcoming domain features in Kanidm, as well as himmelblau to decrypt PRTs.

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
