### PR TITLE
Strongly type the CEK for OAPXBC

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -97,7 +97,31 @@ impl JweEnc {
                 .and_then(|jwe_decipher| jwe_decipher.decipher_inner(jwec)),
         }
     }
+
+    pub(crate) fn yield_cipher(self, key_buffer: &[u8]) -> Result<JweCipher, JwtError> {
+        match self {
+            JweEnc::A128GCM => {
+                a128gcm::JweA128GCMEncipher::try_from(key_buffer).map(JweCipher::A128GCM)
+            }
+            JweEnc::A256GCM => {
+                a256gcm::JweA256GCMEncipher::try_from(key_buffer).map(JweCipher::A256GCM)
+            }
+            JweEnc::A128CBC_HS256 => Err(JwtError::CipherUnavailable),
+        }
+    }
 }
+
+/// A [MS-OAPXBC] 3.2.5.1.2.2 yielded CEK. This is used as a form of key agreement
+/// for MS clients, where this CEK can now be used to encipher and decipher arbitrary
+/// content.
+pub enum JweCipher {
+    /// AES-128-GCM CEK
+    A128GCM(a128gcm::JweA128GCMEncipher),
+    /// AES-256-GCM CEK
+    A256GCM(a256gcm::JweA256GCMEncipher),
+}
+
+// TODO: We need to support arbitrary message enc/dec here. Need to check what MS expects.
 
 impl JweCompact {
     #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,8 @@ pub enum JwtError {
     InvalidKey,
     /// A required header value is not set
     CriticalMissingHeaderValue,
+    /// The requested JWE cipher is not available.
+    CipherUnavailable,
 }
 
 impl fmt::Display for JwtError {


### PR DESCRIPTION
This extends @dmulder's initial work on yielding the CEK, to strongly type and wrap the returned CEK with one of our existing cipher types. We need to investigate what operations will be needed with this agreed CEK. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
