### PR TITLE
Allow signing a JWS without adding a KID

### DIFF
--- a/src/crypto/es256.rs
+++ b/src/crypto/es256.rs
@@ -19,6 +19,8 @@ use crate::traits::*;
 pub struct JwsEs256Signer {
     /// If the public jwk should be embeded during signing
     sign_option_embed_jwk: bool,
+    /// If the KID should be embedded during singing
+    sign_option_embed_kid: bool,
     /// The KID of this validator
     kid: String,
     /// Private Key
@@ -115,6 +117,7 @@ impl JwsEs256Signer {
             skey,
             digest,
             sign_option_embed_jwk: false,
+            sign_option_embed_kid: true,
         })
     }
 
@@ -146,6 +149,7 @@ impl JwsEs256Signer {
             skey,
             digest,
             sign_option_embed_jwk: false,
+            sign_option_embed_kid: true,
         })
     }
 
@@ -168,6 +172,7 @@ impl JwsEs256Signer {
             skey,
             digest,
             sign_option_embed_jwk: false,
+            sign_option_embed_kid: true,
         })
     }
 
@@ -258,7 +263,8 @@ impl JwsSigner for JwsEs256Signer {
         // Update the alg to match.
         header.alg = JwaAlg::ES256;
 
-        header.kid = Some(self.kid.clone());
+        // If the signer is configured to include the KID
+        header.kid = self.sign_option_embed_kid.then(|| self.kid.clone());
 
         // if were were asked to ember the jwk, do so now.
         if self.sign_option_embed_jwk {
@@ -329,6 +335,13 @@ impl JwsSigner for JwsEs256Signer {
         };
 
         jws.post_process(jwsc)
+    }
+
+    fn set_sign_option_embed_kid(&self, value: bool) -> Self {
+        JwsEs256Signer {
+            sign_option_embed_kid: value,
+            ..self.to_owned()
+        }
     }
 }
 

--- a/src/crypto/ms_oapxbc.rs
+++ b/src/crypto/ms_oapxbc.rs
@@ -258,6 +258,12 @@ impl JwsSigner for MsOapxbcSessionKeyHs256 {
 
         self.hmac_key.sign_inner(jws, sign_data)
     }
+    fn set_sign_option_embed_kid(&self, value: bool) -> Self {
+        MsOapxbcSessionKeyHs256 {
+            hmac_key: self.hmac_key.set_sign_option_embed_kid(value),
+            nonce: self.nonce,
+        }
+    }
 }
 
 pub(crate) fn nist_sp800_108_kdf_hmac_sha256(

--- a/src/crypto/rs256.rs
+++ b/src/crypto/rs256.rs
@@ -21,6 +21,8 @@ const RSA_SIG_SIZE: i32 = 384;
 pub struct JwsRs256Signer {
     /// If the public jwk should be embeded during signing
     sign_option_embed_jwk: bool,
+    /// If the KID should be embedded during signing
+    sign_option_embed_kid: bool,
     /// The KID of this validator
     kid: String,
     /// Private Key
@@ -78,6 +80,7 @@ impl JwsRs256Signer {
             skey,
             digest,
             sign_option_embed_jwk: false,
+            sign_option_embed_kid: true,
         })
     }
 
@@ -108,6 +111,7 @@ impl JwsRs256Signer {
             skey,
             digest,
             sign_option_embed_jwk: false,
+            sign_option_embed_kid: true,
         })
     }
 
@@ -164,7 +168,8 @@ impl JwsSigner for JwsRs256Signer {
         // Update the alg to match.
         header.alg = JwaAlg::RS256;
 
-        header.kid = Some(self.kid.clone());
+        // If the signer is configured to include the KID
+        header.kid = self.sign_option_embed_kid.then(|| self.kid.clone());
 
         // if were were asked to ember the jwk, do so now.
         if self.sign_option_embed_jwk {
@@ -224,6 +229,13 @@ impl JwsSigner for JwsRs256Signer {
         };
 
         jws.post_process(jwsc)
+    }
+
+    fn set_sign_option_embed_kid(&self, value: bool) -> Self {
+        JwsRs256Signer {
+            sign_option_embed_kid: value,
+            ..self.to_owned()
+        }
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -18,6 +18,9 @@ pub trait JwsSigner {
 
     /// Perform the signature operation
     fn sign<V: JwsSignable>(&self, _jws: &V) -> Result<V::Signed, JwtError>;
+
+    /// Enable or disable embedding the KID in the Jws header
+    fn set_sign_option_embed_kid(&self, value: bool) -> Self;
 }
 
 /// A trait defining how a JwsSigner will operate.


### PR DESCRIPTION
Implements a new function on the JwsSigner trait and some changes to the trait implementors.

closes #19 

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
