### PR TITLE
Update API surface to support Kanidm KeyObjects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "^1.0.136", features = ["derive"] }
 serde_json = "^1.0.79"
 base64 = "^0.21.5"
 base64urlsafedata = "0.1.0"
-kanidm-hsm-crypto = { version = "^0.1.6", optional = true }
+kanidm-hsm-crypto = { version = "^0.2.0", optional = true }
 # kanidm-hsm-crypto = { path = "../hsm-crypto", optional = true }
 openssl = { version = "^0.10.38", optional = true }
 openssl-kdf = { version = "0.4.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact_jwt"
-version = "0.3.5"
+version = "0.4.0-dev"
 edition = "2021"
 authors = ["William Brown <william@blackhats.net.au>"]
 description = "Minimal implementation of JWT for OIDC and other applications"

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -152,11 +152,6 @@ impl fmt::Debug for JwsCompact {
 }
 
 impl JwsCompact {
-    /// Get the KID used to sign this Jws if present
-    pub fn get_jwk_kid(&self) -> Option<&str> {
-        self.header.kid.as_deref()
-    }
-
     /// Get the embedded Url for the Jwk that signed this Jws.
     ///
     /// You MUST ensure this url uses HTTPS and you MUST ensure that your
@@ -259,6 +254,14 @@ impl JwsVerifiable for JwsCompact {
             payload_bytes: self.payload_b64.as_bytes(),
             signature_bytes: self.signature.as_slice(),
         }
+    }
+
+    fn alg(&self) -> JwaAlg {
+        self.header.alg
+    }
+
+    fn kid(&self) -> Option<&str> {
+        self.header.kid.as_deref()
     }
 
     fn post_process(&self, value: Jws) -> Result<Self::Verified, JwtError> {
@@ -384,9 +387,18 @@ pub struct JweCompact {
     pub(crate) authentication_tag: Vec<u8>,
 }
 
+impl fmt::Debug for JweCompact {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JweCompact")
+            .field("header", &self.header)
+            .field("encrypted_payload_length", &self.ciphertext.len())
+            .finish()
+    }
+}
+
 impl JweCompact {
     /// Get the KID used to encipher this Jwe if present
-    pub fn get_jwk_kid(&self) -> Option<&str> {
+    pub fn kid(&self) -> Option<&str> {
         self.header.kid.as_deref()
     }
 
@@ -401,6 +413,11 @@ impl JweCompact {
     /// Get the embedded public key used to encipher this Jwe, if present.
     pub fn get_jwk_pubkey(&self) -> Option<&Jwk> {
         self.header.jwk.as_ref()
+    }
+
+    /// Return the CEK Algorithm and the inner encryption type.
+    pub fn get_alg_enc(&self) -> (JweAlg, JweEnc) {
+        (self.header.alg, self.header.enc)
     }
 }
 

--- a/src/crypto/a128gcm.rs
+++ b/src/crypto/a128gcm.rs
@@ -13,6 +13,8 @@ pub(crate) const KEY_LEN: usize = 16;
 const IV_LEN: usize = 12;
 const AUTH_TAG_LEN: usize = 16;
 
+/// A JWE inner encipher and decipher for AES 128 GCM. This is the recommended inner
+/// encryption algorithm to use.
 #[derive(Clone)]
 pub struct JweA128GCMEncipher {
     aes_key: [u8; KEY_LEN],
@@ -93,11 +95,12 @@ impl JweEncipherInner for JweA128GCMEncipher {
 }
 
 impl JweA128GCMEncipher {
+    /// The required length for this cipher key
     pub fn key_len() -> usize {
-        16
+        KEY_LEN
     }
 
-    pub fn decipher_inner(&self, jwec: &JweCompact) -> Result<Vec<u8>, JwtError> {
+    pub(crate) fn decipher_inner(&self, jwec: &JweCompact) -> Result<Vec<u8>, JwtError> {
         aes_gcm_decipher(
             Cipher::aes_128_gcm(),
             &jwec.ciphertext,

--- a/src/crypto/a128kw.rs
+++ b/src/crypto/a128kw.rs
@@ -1,7 +1,7 @@
 use crate::compact::{JweAlg, JweCompact, JweProtectedHeader};
 use crate::jwe::Jwe;
 use crate::traits::*;
-use crate::JwtError;
+use crate::{JwtError, KID_LEN};
 
 use openssl::aes::{unwrap_key, wrap_key, AesKey};
 use openssl::hash;
@@ -177,8 +177,7 @@ impl TryFrom<[u8; KEY_LEN]> for JweA128KWEncipher {
         let kid = hash::hash(digest, &wrap_key)
             .map(|hashout| {
                 let mut s = hex::encode(hashout);
-                // 192 bits
-                s.truncate(48);
+                s.truncate(KID_LEN);
                 s
             })
             .map_err(|_| JwtError::OpenSSLError)?;

--- a/src/crypto/a128kw.rs
+++ b/src/crypto/a128kw.rs
@@ -202,7 +202,7 @@ impl TryFrom<&[u8]> for JweA128KWEncipher {
 
         let mut wrap_key = [0; KEY_LEN];
 
-        wrap_key.copy_from_slice(&value);
+        wrap_key.copy_from_slice(value);
 
         Self::try_from(wrap_key)
     }

--- a/src/crypto/a256gcm.rs
+++ b/src/crypto/a256gcm.rs
@@ -14,6 +14,7 @@ pub(crate) const KEY_LEN: usize = 32;
 const IV_LEN: usize = 12;
 const AUTH_TAG_LEN: usize = 16;
 
+/// A JWE inner encipher and decipher for AES 256 GCM.
 #[derive(Clone)]
 pub struct JweA256GCMEncipher {
     aes_key: [u8; KEY_LEN],
@@ -111,11 +112,12 @@ impl JweEncipherInner for JweA256GCMEncipher {
 }
 
 impl JweA256GCMEncipher {
+    /// The required length for this cipher key
     pub fn key_len() -> usize {
         KEY_LEN
     }
 
-    pub fn decipher_inner(&self, jwec: &JweCompact) -> Result<Vec<u8>, JwtError> {
+    pub(crate) fn decipher_inner(&self, jwec: &JweCompact) -> Result<Vec<u8>, JwtError> {
         super::a128gcm::aes_gcm_decipher(
             Cipher::aes_256_gcm(),
             &jwec.ciphertext,

--- a/src/crypto/ecdhes_a128kw.rs
+++ b/src/crypto/ecdhes_a128kw.rs
@@ -91,7 +91,7 @@ impl JweEncipherOuter for JweEcdhEsA128KWEncipher {
 
         derive_key(&self.priv_key, &self.peer_public_key).and_then(|wrapping_key|
                 // use A128KW with the derived wrap key as usual.
-                JweA128KWEncipher::from(wrapping_key)
+                JweA128KWEncipher::load_ephemeral(wrapping_key)
                     .wrap_key(key_to_wrap))
     }
 }
@@ -228,10 +228,10 @@ impl JweEcdhEsA128KWDecipher {
             }
         };
 
-        derive_key(&self.priv_key, &ephemeral_public_key).and_then(|wrapping_key|
-                // use A128KW with the derived wrap key as usual.
-                JweA128KWEncipher::from(wrapping_key)
-                    .decipher(jwec))
+        derive_key(&self.priv_key, &ephemeral_public_key).and_then(|wrapping_key| {
+            // use A128KW with the derived wrap key as usual.
+            JweA128KWEncipher::load_ephemeral(wrapping_key).decipher(jwec)
+        })
     }
 }
 

--- a/src/crypto/es256.rs
+++ b/src/crypto/es256.rs
@@ -5,6 +5,7 @@ use openssl::{bn, ec, ecdsa, hash, nid, pkey};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+use crate::KID_LEN;
 use crate::error::JwtError;
 
 use base64::{engine::general_purpose, Engine as _};
@@ -110,7 +111,7 @@ impl JwsEs256Signer {
         let legacy_kid = skey
             .private_key_to_der()
             .and_then(|der| hash::hash(digest, &der))
-            .map(|hashout| hex::encode(hashout))
+            .map(hex::encode)
             .map_err(|e| {
                 debug!(?e);
                 JwtError::OpenSSLError
@@ -121,8 +122,7 @@ impl JwsEs256Signer {
             .and_then(|der| hash::hash(digest, &der))
             .map(|hashout| {
                 let mut s = hex::encode(hashout);
-                // 192 bits
-                s.truncate(48);
+                s.truncate(KID_LEN);
                 s
             })
             .map_err(|e| {
@@ -161,7 +161,7 @@ impl JwsEs256Signer {
         let legacy_kid = skey
             .private_key_to_der()
             .and_then(|der| hash::hash(digest, &der))
-            .map(|hashout| hex::encode(hashout))
+            .map(hex::encode)
             .map_err(|e| {
                 debug!(?e);
                 JwtError::OpenSSLError
@@ -172,8 +172,7 @@ impl JwsEs256Signer {
             .and_then(|der| hash::hash(digest, &der))
             .map(|hashout| {
                 let mut s = hex::encode(hashout);
-                // 192 bits
-                s.truncate(48);
+                s.truncate(KID_LEN);
                 s
             })
             .map_err(|e| {
@@ -246,7 +245,7 @@ impl JwsEs256Signer {
         public_key_as_jwk(pkey, ec_group, self.kid.clone())
     }
 
-    /// Unable use of the legacy KID for transitional purposes. This will be
+    /// Enable use of the legacy KID for transitional purposes. This will be
     /// removed in a future version!
     pub fn set_sign_option_legacy_kid(&self, value: bool) -> Self {
         JwsEs256Signer {

--- a/src/crypto/es256.rs
+++ b/src/crypto/es256.rs
@@ -5,8 +5,8 @@ use openssl::{bn, ec, ecdsa, hash, nid, pkey};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use crate::KID_LEN;
 use crate::error::JwtError;
+use crate::KID_LEN;
 
 use base64::{engine::general_purpose, Engine as _};
 use base64urlsafedata::Base64UrlSafeData;

--- a/src/crypto/hs256.rs
+++ b/src/crypto/hs256.rs
@@ -1,6 +1,7 @@
 //! JWS Signing and Verification Structures
 
 use crate::error::JwtError;
+use crate::KID_LEN;
 use openssl::{hash, pkey, rand, sign};
 
 use std::fmt;
@@ -66,8 +67,7 @@ impl JwsHs256Signer {
         let kid = hash::hash(digest, &buf)
             .map(|hashout| {
                 let mut s = hex::encode(hashout);
-                // 192 bits
-                s.truncate(48);
+                s.truncate(KID_LEN);
                 s
             })
             .map_err(|_| JwtError::OpenSSLError)?;
@@ -135,8 +135,7 @@ impl TryFrom<&[u8]> for JwsHs256Signer {
         let kid = hash::hash(digest, buf)
             .map(|hashout| {
                 let mut s = hex::encode(hashout);
-                // 192 bits
-                s.truncate(48);
+                s.truncate(KID_LEN);
                 s
             })
             .map_err(|_| JwtError::OpenSSLError)?;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -32,7 +32,9 @@ pub use hs256::JwsHs256Signer;
 pub use rs256::{JwsRs256Signer, JwsRs256Verifier};
 pub use x509::{JwsX509Verifier, JwsX509VerifierBuilder};
 
+pub use a128gcm::JweA128GCMEncipher;
 pub use a128kw::JweA128KWEncipher;
+pub use a256gcm::JweA256GCMEncipher;
 pub use a256kw::JweA256KWEncipher;
 pub use ecdhes_a128kw::{JweEcdhEsA128KWDecipher, JweEcdhEsA128KWEncipher};
 pub use rsaes_oaep::{JweRSAOAEPDecipher, JweRSAOAEPEncipher};

--- a/src/crypto/rs256.rs
+++ b/src/crypto/rs256.rs
@@ -5,8 +5,8 @@ use openssl::{bn, hash, pkey, rsa, sign};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use crate::KID_LEN;
 use crate::error::JwtError;
+use crate::KID_LEN;
 use base64::{engine::general_purpose, Engine as _};
 use base64urlsafedata::Base64UrlSafeData;
 

--- a/src/crypto/rs256.rs
+++ b/src/crypto/rs256.rs
@@ -5,6 +5,7 @@ use openssl::{bn, hash, pkey, rsa, sign};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+use crate::KID_LEN;
 use crate::error::JwtError;
 use base64::{engine::general_purpose, Engine as _};
 use base64urlsafedata::Base64UrlSafeData;
@@ -81,8 +82,7 @@ impl JwsRs256Signer {
             .and_then(|der| hash::hash(digest, &der))
             .map(|hashout| {
                 let mut s = hex::encode(hashout);
-                // 192 bits
-                s.truncate(48);
+                s.truncate(KID_LEN);
                 s
             })
             .map_err(|e| {
@@ -338,8 +338,7 @@ impl TryFrom<&Jwk> for JwsRs256Verifier {
                         .and_then(|der| hash::hash(digest, &der))
                         .map(|hashout| {
                             let mut s = hex::encode(hashout);
-                            // 192 bits
-                            s.truncate(48);
+                            s.truncate(KID_LEN);
                             s
                         })
                         .map_err(|e| {

--- a/src/crypto/tpm.rs
+++ b/src/crypto/tpm.rs
@@ -40,6 +40,10 @@ where
         self.kid.as_str()
     }
 
+    fn get_legacy_kid(&mut self) -> &str {
+        self.kid.as_str()
+    }
+
     fn update_header(&mut self, header: &mut ProtectedHeader) -> Result<(), JwtError> {
         // Update the alg to match.
         match self.id_key.alg() {
@@ -127,8 +131,8 @@ where
     T: Tpm,
 {
     /// Get the key id from this verifier
-    fn get_kid(&mut self) -> Option<&str> {
-        Some(JwsMutSigner::get_kid(self))
+    fn get_kid(&mut self) -> &str {
+        JwsMutSigner::get_kid(self)
     }
 
     /// Perform the signature verification

--- a/src/crypto/x509.rs
+++ b/src/crypto/x509.rs
@@ -153,7 +153,7 @@ impl JwsX509VerifierBuilder {
             leaf.public_key()
                 .and_then(|pkey| pkey.public_key_to_der())
                 .and_then(|der| hash::hash(digest, &der))
-                .map(|hashout| hex::encode(hashout))
+                .map(hex::encode)
                 .map_err(|e| {
                     debug!(?e);
                     JwtError::OpenSSLError

--- a/src/dangernoverify.rs
+++ b/src/dangernoverify.rs
@@ -10,8 +10,9 @@ use crate::traits::{JwsVerifiable, JwsVerifier};
 pub struct JwsDangerReleaseWithoutVerify {}
 
 impl JwsVerifier for JwsDangerReleaseWithoutVerify {
-    fn get_kid(&self) -> Option<&str> {
-        None
+    /// Get the key id from this verifier
+    fn get_kid(&self) -> &str {
+        "JwsDangerReleaseWithoutVerify"
     }
 
     fn verify<V: JwsVerifiable>(&self, jwsc: &V) -> Result<V::Verified, JwtError> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,8 @@ pub enum JwtError {
     CipherUnavailable,
     /// The JWE algorithm does not match this decipher.
     AlgorithmUnavailable,
+    /// The request to release the key is unable to be satisfied.
+    UnableToReleaseKey,
 }
 
 impl fmt::Display for JwtError {

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -28,6 +28,14 @@ impl From<Vec<u8>> for JwsBuilder {
 }
 
 impl JwsBuilder {
+    /// Create a new builder from a serialisable type
+    pub fn into_json<T: Serialize>(value: &T) -> Result<Self, serde_json::Error> {
+        serde_json::to_vec(value).map(|payload| JwsBuilder {
+            header: ProtectedHeader::default(),
+            payload,
+        })
+    }
+
     /// Set the content type of this JWS
     pub fn set_typ(mut self, typ: Option<&str>) -> Self {
         self.header.typ = typ.map(|s| s.to_string());
@@ -46,7 +54,7 @@ impl JwsBuilder {
         self
     }
 
-    /// Set the kid
+    #[cfg(test)]
     pub fn set_kid(mut self, kid: Option<&str>) -> Self {
         self.header.kid = kid.map(|s| s.to_string());
         self

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,7 +1,7 @@
 //! Jwt implementation
 
 use crate::btreemap_empty;
-use crate::compact::{Jwk, JwsCompact, JwsCompactVerifyData};
+use crate::compact::{JwaAlg, Jwk, JwsCompact, JwsCompactVerifyData};
 use crate::error::JwtError;
 use crate::jws::{Jws, JwsCompactSign2Data, JwsSigned};
 use crate::traits::{JwsSignable, JwsVerifiable};
@@ -145,6 +145,14 @@ where
         self.jwsc.data()
     }
 
+    fn alg(&self) -> JwaAlg {
+        self.jwsc.alg()
+    }
+
+    fn kid(&self) -> Option<&str> {
+        self.jwsc.kid()
+    }
+
     fn post_process(&self, value: Jws) -> Result<Self::Verified, JwtError> {
         value.from_json().map_err(|_| JwtError::InvalidJwt)
     }
@@ -157,11 +165,6 @@ where
     /// Get the embedded public key used to sign this jwt, if present.
     pub fn get_jwk_pubkey(&self) -> Option<&Jwk> {
         self.jwsc.get_jwk_pubkey()
-    }
-
-    /// Get the KID used to sign this Jws if present
-    pub fn get_jwk_kid(&self) -> Option<&str> {
-        self.jwsc.get_jwk_kid()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@ pub use crate::oidc::{OidcClaims, OidcSigned, OidcSubject, OidcToken, OidcUnveri
 
 pub use crate::traits::{JwsSigner, JwsSignerToVerifier, JwsVerifier};
 
+const KID_LEN: usize = 32;
+
 pub(crate) fn btreemap_empty(
     m: &std::collections::BTreeMap<String, serde_json::value::Value>,
 ) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub mod oidc;
 #[cfg(feature = "openssl")]
 pub use crate::crypto::{JwsEs256Signer, JwsEs256Verifier, JwsHs256Signer};
 
-pub use crate::compact::{JwaAlg, Jwk, JwkKeySet, JwkUse, JwsCompact};
+pub use crate::compact::{JwaAlg, JweCompact, Jwk, JwkKeySet, JwkUse, JwsCompact};
 pub use crate::error::JwtError;
 pub use crate::jws::{Jws, JwsSigned};
 pub use crate::jwt::{Jwt, JwtSigned, JwtUnverified};

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1,6 +1,6 @@
 //! Oidc token implementation
 
-use crate::compact::{Jwk, JwsCompact, JwsCompactVerifyData};
+use crate::compact::{JwaAlg, Jwk, JwsCompact, JwsCompactVerifyData};
 use crate::jws::{Jws, JwsCompactSign2Data, JwsSigned};
 
 use crate::traits::{JwsSignable, JwsVerifiable};
@@ -144,11 +144,6 @@ impl OidcUnverified {
     pub fn get_jwk_pubkey(&self) -> Option<&Jwk> {
         self.jwsc.get_jwk_pubkey()
     }
-
-    /// Get the KID used to sign this Jws if present
-    pub fn get_jwk_kid(&self) -> Option<&str> {
-        self.jwsc.get_jwk_kid()
-    }
 }
 
 impl FromStr for OidcUnverified {
@@ -164,6 +159,14 @@ impl JwsVerifiable for OidcUnverified {
 
     fn data(&self) -> JwsCompactVerifyData<'_> {
         self.jwsc.data()
+    }
+
+    fn alg(&self) -> JwaAlg {
+        self.jwsc.alg()
+    }
+
+    fn kid(&self) -> Option<&str> {
+        self.jwsc.kid()
     }
 
     fn post_process(&self, value: Jws) -> Result<Self::Verified, JwtError> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
 //! Traits that define behaviour of JWS signing and verification types.
 
-use crate::compact::{JweCompact, JweProtectedHeader};
+use crate::compact::{JwaAlg, JweCompact, JweProtectedHeader};
 use crate::compact::{JwsCompact, JwsCompactVerifyData, ProtectedHeader};
 use crate::error::JwtError;
 use crate::jwe::Jwe;
@@ -12,6 +12,10 @@ use crate::jws::{Jws, JwsCompactSign2Data};
 pub trait JwsSigner {
     /// Get the key id from this signer
     fn get_kid(&self) -> &str;
+
+    /// Get the legacy format key id from this signer. This value will be removed
+    /// in a future release.
+    fn get_legacy_kid(&self) -> &str;
 
     /// Update thee content of the header with signer specific data
     fn update_header(&self, header: &mut ProtectedHeader) -> Result<(), JwtError>;
@@ -29,6 +33,10 @@ pub trait JwsSigner {
 pub trait JwsMutSigner {
     /// Get the key id from this signer
     fn get_kid(&mut self) -> &str;
+
+    /// Get the legacy format key id from this signer. This value will be removed
+    /// in a future release.
+    fn get_legacy_kid(&mut self) -> &str;
 
     /// Update thee content of the header with signer specific data
     fn update_header(&mut self, header: &mut ProtectedHeader) -> Result<(), JwtError>;
@@ -53,7 +61,7 @@ pub trait JwsSignerToVerifier {
 /// Note that due to the design of this api, you can NOT define your own verifier.
 pub trait JwsVerifier {
     /// Get the key id from this verifier
-    fn get_kid(&self) -> Option<&str>;
+    fn get_kid(&self) -> &str;
 
     /// Perform the signature verification
     fn verify<V: JwsVerifiable>(&self, _jwsc: &V) -> Result<V::Verified, JwtError>;
@@ -64,7 +72,7 @@ pub trait JwsVerifier {
 /// Note that due to the design of this api, you can NOT define your own verifier.
 pub trait JwsMutVerifier {
     /// Get the key id from this verifier
-    fn get_kid(&mut self) -> Option<&str>;
+    fn get_kid(&mut self) -> &str;
 
     /// Perform the signature verification
     fn verify<V: JwsVerifiable>(&mut self, _jwsc: &V) -> Result<V::Verified, JwtError>;
@@ -77,6 +85,12 @@ pub trait JwsVerifiable {
 
     /// Retrieve the inner data from the JwsCompact that is to be verified
     fn data(&self) -> JwsCompactVerifyData<'_>;
+
+    /// Access the algorithm that was used to sign this JWS
+    fn alg(&self) -> JwaAlg;
+
+    /// Access the optional Key ID that signed this JWS
+    fn kid(&self) -> Option<&str>;
 
     /// After the verification is complete, allow post-processing of the released payload
     fn post_process(&self, value: Jws) -> Result<Self::Verified, JwtError>;


### PR DESCRIPTION
This updates a large amount of the API surface to support Kanidm key objects. This also changes the way we created the key id to make it more reliable to derive for verifiers.


- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
