### PR TITLE
Fix the msextensions build

### DIFF
--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -22,4 +22,5 @@ jobs:
     - name: Cargo test
       run: cargo test
 
-
+    - name: Cargo test with MS Extensions
+      run: cargo test --features msextensions

--- a/src/crypto/ms_oapxbc.rs
+++ b/src/crypto/ms_oapxbc.rs
@@ -330,6 +330,10 @@ impl JwsSigner for MsOapxbcSessionKeyHs256 {
         JwsSigner::get_kid(&self.hmac_key)
     }
 
+    fn get_legacy_kid(&self) -> &str {
+        JwsSigner::get_kid(&self.hmac_key)
+    }
+
     fn update_header(&self, header: &mut ProtectedHeader) -> Result<(), JwtError> {
         let ctx = general_purpose::STANDARD.encode(self.nonce);
         header.ctx = Some(ctx);

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -54,7 +54,7 @@ impl JwsBuilder {
         self
     }
 
-    #[cfg(test)]
+    /// Set the kid (required for Windows Hello/MS Extensions)
     pub fn set_kid(mut self, kid: Option<&str>) -> Self {
         self.header.kid = kid.map(|s| s.to_string());
         self


### PR DESCRIPTION
get_legacy_kid wasn't implemented for ms_oapxbc.

Implements # .

- [ ] cargo fmt has been run
- [ ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
