### PR TITLE
Updates for webauthn-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact_jwt"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["William Brown <william@blackhats.net.au>"]
 description = "Minimal implementation of JWT for OIDC and other applications"

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,8 @@ pub enum JwtError {
     AlgorithmUnavailable,
     /// The request to release the key is unable to be satisfied.
     UnableToReleaseKey,
+    /// Serialisation / Deserialisation error
+    Serde,
 }
 
 impl fmt::Display for JwtError {


### PR DESCRIPTION
Updates to 0.4.2 to support webauthn-rs update https://github.com/kanidm/webauthn-rs/issues/443 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] documentation has been updated with relevant examples (if relevant)
