### PR TITLE
Add ability to set cert thumbprint in JwsBuilder

### DIFF
--- a/src/compact.rs
+++ b/src/compact.rs
@@ -119,7 +119,7 @@ pub struct ProtectedHeader {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) x5c: Option<Vec<String>>,
     #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
-    pub(crate) x5t: Option<()>,
+    pub(crate) x5t: Option<String>,
     #[serde(
         skip_deserializing,
         rename = "x5t#S256",

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -78,6 +78,12 @@ impl JwsBuilder {
         self
     }
 
+    /// Set the certificate thumbprint
+    pub fn set_x5t(mut self, thumbprint: &str) -> Self {
+        self.header.x5t = Some(thumbprint.to_string());
+        self
+    }
+
     /// Finalise this builder
     pub fn build(self) -> Jws {
         let JwsBuilder { header, payload } = self;


### PR DESCRIPTION
Implements # .

- [ ] cargo fmt has been run
- [ ] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
