### PR TITLE
20250710 fix rsa import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact_jwt"
-version = "0.5.2-dev"
+version = "0.5.3-dev"
 edition = "2021"
 authors = ["William Brown <william@blackhats.net.au>"]
 description = "Minimal implementation of JWT for OIDC and other applications"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "^0.21.5"
 base64urlsafedata = "^0.5.1"
 
 crypto-glue = "^0.1.7"
-kanidm-hsm-crypto = "0.3.2"
+kanidm-hsm-crypto = "^0.3.2"
 
 url = { version = "^2.2.2", features = ["serde"] }
 uuid = { version = "^1.0.0", features = ["serde"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,7 @@ pub enum JwtError {
 
 impl fmt::Display for JwtError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -43,8 +43,8 @@ pub enum OidcSubject {
 impl fmt::Display for OidcSubject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            OidcSubject::U(u) => write!(f, "{}", u),
-            OidcSubject::S(s) => write!(f, "{}", s),
+            OidcSubject::U(u) => write!(f, "{u}"),
+            OidcSubject::S(s) => write!(f, "{s}"),
         }
     }
 }


### PR DESCRIPTION
Previously when we used openssl we exported private keys with pkcs1. I mistakenly started to export/import these with pkcs8, which broke other applications.

Instead, we should try both pkcs1/8 import, and export only as pkcs8.

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
