### PR TITLE
Revert "Add OAuth2 ClientID to protected headers (#50)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact_jwt"
-version = "0.5.6"
+version = "0.5.5"
 edition = "2021"
 authors = ["William Brown <william@blackhats.net.au>"]
 description = "Minimal implementation of JWT for OIDC and other applications"

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -96,59 +96,41 @@ pub enum JwaAlg {
     HS256,
 }
 
-/// A header that will be signed and embedded in the Jws. For defined claims see
-/// the [IANA JOSE Registry](https://www.iana.org/assignments/jose/jose.xhtml)
+/// A header that will be signed and embedded in the Jws
 #[derive(Debug, Serialize, Clone, Deserialize, Default, PartialEq)]
-#[serde(rename_all = "snake_case")]
 pub struct ProtectedHeader {
-    /// The encryption algorithm used in this JWS
-    pub alg: JwaAlg,
-    /// JWS Key Set URL
+    pub(crate) alg: JwaAlg,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jku: Option<Url>,
-    /// The JWK that signs this JWS
+    pub(crate) jku: Option<Url>,
+    // https://datatracker.ietf.org/doc/html/rfc7517
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jwk: Option<Jwk>,
-    /// Key Identifier String
+    pub(crate) jwk: Option<Jwk>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub kid: Option<String>,
-    /// Criticality of this header and processing it's content
+    pub(crate) kid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub crit: Option<Vec<String>>,
-    /// Type
+    pub(crate) crit: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub typ: Option<String>,
-    /// Content
+    pub(crate) typ: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cty: Option<String>,
+    pub(crate) cty: Option<String>,
 
-    /// X509 URL
     #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
-    pub x5u: Option<()>,
-    /// X509 Chain
+    pub(crate) x5u: Option<()>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub x5c: Option<Vec<String>>,
-    /// X509 S1 Thumbprint
+    pub(crate) x5c: Option<Vec<String>>,
     #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
-    pub x5t: Option<String>,
+    pub(crate) x5t: Option<String>,
     #[serde(
         skip_deserializing,
         rename = "x5t#S256",
         skip_serializing_if = "Option::is_none"
     )]
-    /// X509 S256 Thumbprint
-    pub x5t_s256: Option<()>,
-    /// Context
+    pub(crate) x5t_s256: Option<()>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ctx: Option<String>,
-    /// Microsoft Extension - JWS usage
+    pub(crate) ctx: Option<String>,
     #[cfg(feature = "msextensions")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub r#use: Option<String>,
-
-    /// OAuth2 Extension - the client_id that issued this JWS
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_id: Option<String>,
+    pub(crate) r#use: Option<String>,
 }
 
 /// A Compact JWS that is able to be verified or stringified for transmission
@@ -181,12 +163,6 @@ impl JwsCompact {
     /// Get the embedded public key used to sign this Jws, if present.
     pub fn get_jwk_pubkey(&self) -> Option<&Jwk> {
         self.header.jwk.as_ref()
-    }
-
-    /// View the content of the JWS header. At this point the content is UNVERIFIED
-    /// and may NOT BE TRUSTED.
-    pub fn header(&self) -> &ProtectedHeader {
-        &self.header
     }
 }
 
@@ -399,63 +375,46 @@ pub enum JweEnc {
     // A128CBC_HS256,
 }
 
-/// A header that will be signed and embedded in the Jwe. For defined claims see
-/// the [IANA JOSE Registry](https://www.iana.org/assignments/jose/jose.xhtml)
+/// A header that will be signed and embedded in the Jws
 #[derive(Debug, Serialize, Clone, Deserialize, Default, PartialEq)]
-#[serde(rename_all = "snake_case")]
 pub struct JweProtectedHeader {
-    /// The key wrap/derivation algorithm in use protecting the payload key
-    pub alg: JweAlg,
+    pub(crate) alg: JweAlg,
 
-    /// The inner encryption of this JWE
-    pub enc: JweEnc,
+    pub(crate) enc: JweEnc,
 
-    /// Ephemeral Public Key
+    // https://www.rfc-editor.org/rfc/rfc7518#section-4.6.1.1
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub epk: Option<Jwk>,
+    pub(crate) epk: Option<Jwk>,
 
-    /// JWS Key Set URL
+    // zip
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jku: Option<Url>,
+    pub(crate) jku: Option<Url>,
+    // https://datatracker.ietf.org/doc/html/rfc7517
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) jwk: Option<Jwk>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) kid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) crit: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) typ: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cty: Option<String>,
 
-    /// Embedded JWK
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub jwk: Option<Jwk>,
-    ///Key Identifier String
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub kid: Option<String>,
-    /// Criticality of this header and processing it's content
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub crit: Option<Vec<String>>,
-    /// Type
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub typ: Option<String>,
-    /// Content
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cty: Option<String>,
-
-    /// X509 URL
     #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
-    pub x5u: Option<()>,
-    /// X509 Chain
+    pub(crate) x5u: Option<()>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub x5c: Option<Vec<String>>,
-    /// X509 S1 Thumbprint
+    pub(crate) x5c: Option<Vec<String>>,
     #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
-    pub x5t: Option<()>,
-    /// X509 S256 Thumbprint
+    pub(crate) x5t: Option<()>,
     #[serde(
         skip_deserializing,
         rename = "x5t#S256",
         skip_serializing_if = "Option::is_none"
     )]
-    pub x5t_s256: Option<()>,
-    /// Context
+    pub(crate) x5t_s256: Option<()>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ctx: Option<String>,
-    /// OAuth2 Extension - the client_id that issued this JWE
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_id: Option<String>,
+    pub(crate) ctx: Option<String>,
 }
 
 /// A Compact JWE that is able to be deciphered or stringified for transmission
@@ -500,12 +459,6 @@ impl JweCompact {
     /// Return the CEK Algorithm and the inner encryption type.
     pub fn get_alg_enc(&self) -> (JweAlg, JweEnc) {
         (self.header.alg, self.header.enc)
-    }
-
-    /// View the content of the JWE header. At this point the content is UNVERIFIED
-    /// and may NOT BE TRUSTED.
-    pub fn header(&self) -> &JweProtectedHeader {
-        &self.header
     }
 }
 

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -19,15 +19,6 @@ impl From<Vec<u8>> for JweBuilder {
 }
 
 impl JweBuilder {
-    /// Create a JWE from a serialisable type. This assumes you want to encode
-    /// the input value with json.
-    pub fn into_json<T: Serialize>(value: &T) -> Result<Self, serde_json::Error> {
-        serde_json::to_vec(value).map(|payload| JweBuilder {
-            header: JweProtectedHeader::default(),
-            payload,
-        })
-    }
-
     /// Set the content type of this JWE
     pub fn set_typ(mut self, typ: Option<&str>) -> Self {
         self.header.typ = typ.map(|s| s.to_string());
@@ -37,12 +28,6 @@ impl JweBuilder {
     /// Set the content type of the payload
     pub fn set_cty(mut self, cty: Option<&str>) -> Self {
         self.header.cty = cty.map(|s| s.to_string());
-        self
-    }
-
-    /// Set the OAuth2 Client ID
-    pub fn set_client_id(mut self, client_id: Option<&str>) -> Self {
-        self.header.client_id = client_id.map(|s| s.to_string());
         self
     }
 
@@ -61,14 +46,9 @@ pub struct Jwe {
 }
 
 impl Jwe {
-    /// Get the bytes of the payload of this JWE
+    /// Get the bytes of the payload of this JWS
     pub fn payload(&self) -> &[u8] {
         &self.payload
-    }
-
-    /// View the authenticated header content
-    pub fn header(&self) -> &JweProtectedHeader {
-        &self.header
     }
 
     /// Create a JWE from a serialisable type. This assumes you want to encode

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -84,12 +84,6 @@ impl JwsBuilder {
         self
     }
 
-    /// Set the OAuth2 Client ID
-    pub fn set_client_id(mut self, client_id: Option<&str>) -> Self {
-        self.header.client_id = client_id.map(|s| s.to_string());
-        self
-    }
-
     /// Finalise this builder
     pub fn build(self) -> Jws {
         let JwsBuilder { header, payload } = self;
@@ -108,11 +102,6 @@ impl Jws {
     /// Get the bytes of the payload of this JWS
     pub fn payload(&self) -> &[u8] {
         &self.payload
-    }
-
-    /// View the authenticated header content
-    pub fn header(&self) -> &ProtectedHeader {
-        &self.header
     }
 
     /// Create a JWS from a serialisable type. This assumes you want to encode


### PR DESCRIPTION
This reverts commit 95a3eb9cbc9e9c3272a18ed243ee75d08c291f4e.

Other JWT impls don't allow non-standard protected header elements - this reverts the commit so that we don't accidently step on these again. 

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] documentation has been updated with relevant examples (if relevant)
